### PR TITLE
fix: Correct date formatting in Hero component for La Meetup 2025

### DIFF
--- a/src/components/Meetups/2025/Hero/index.tsx
+++ b/src/components/Meetups/2025/Hero/index.tsx
@@ -31,7 +31,7 @@ export default function Hero({ sponsors }: HeroProps) {
           <div className="flex w-full flex-col gap-2">
             <span className="flex w-full flex-col items-center justify-center">
               <h2 className="animate-fadeIn animate-delay-200 text-center text-3xl font-extrabold text-white md:text-4xl lg:text-5xl">
-                {format(parseISO(new Date("2025-11-01 00:00:00").toISOString()), "dd 'de' MMMM yyyy", {
+                {format(parseISO(new Date("2025-11-01 00:00:00").toISOString()), "d 'de' MMMM yyyy", {
                   locale: es,
                 })}
               </h2>


### PR DESCRIPTION
This pull request includes a minor change to the `Hero` component in the `src/components/Meetups/2025/Hero/index.tsx` file. The change adjusts the date format in the rendered output.

* [`src/components/Meetups/2025/Hero/index.tsx`](diffhunk://#diff-5b05914b4d0ab613cc271920d5c7fe195354ed7bfbe0e2c3e35d4efa228dfac4L34-R34): Modified the date format in the `h2` element from "dd 'de' MMMM yyyy" to "d 'de' MMMM yyyy".