### PR TITLE
fix: Update URLs in La Meetup 2024 landing page

### DIFF
--- a/content/la-meetup-2024/la-meetup/index.yaml
+++ b/content/la-meetup-2024/la-meetup/index.yaml
@@ -8,9 +8,9 @@ primaryButtonName: AGREGAR AL CALENDARIO
 primaryButtonUrl: >-
   https://www.google.com/calendar/render?action=TEMPLATE&text=La+Meetup&details=La+meetup+descripci%C3%B3n&location=Sinergia+Faro%2C+V%C3%ADctor+Soli%C3%B1o+349%2C+Montevideo&dates=20241019T120000Z%2F20241019T210000Z
 secondaryButtonName: ¡REVIVÍ LA MEETUP!
-secondaryButtonUrl: /la-meetup/#galeria
+secondaryButtonUrl: /2024/la-meetup/#galeria
 ctaText: ¡Te invitamos a conocer más acerca de la meetup!
-ctaUrl: /la-meetup/#bienvenida
+ctaUrl: /2024/la-meetup/#bienvenida
 agenda:
   - id: 1
     title: Recepción y desayuno


### PR DESCRIPTION
## Summary

This pull request updates URLs in the `content/la-meetup-2024/la-meetup/index.yaml` file to reflect the 2024 edition of the La Meetup event. The changes ensure that internal links correctly point to the relevant sections for this year’s content.

## Detailed Description

The primary goal of this update is to align the URL references within the content configuration file with the 2024 event structure. Specifically, two key fields in the YAML file have been modified:

- **`secondaryButtonUrl`** was updated from its previous value to `/2024/la-meetup/#galeria` to correctly point to the 2024 gallery section.
- **`ctaUrl`** was updated to `/2024/la-meetup/#bienvenida`, linking to the welcome section of the 2024 event page.

These adjustments are necessary to ensure consistency across the event site and to avoid broken or outdated links.

## Impact

- Affects: `content/la-meetup-2024/la-meetup/index.yaml`
- No changes were made to functionality or layout—this is a content reference update only.
- No external dependencies are affected.

## Testing & Validation

- Verified that the updated URLs match the 2024 route structure.
- Manually tested the paths in a local/staging environment to confirm the links navigate to the correct anchor points.
