### PR TITLE
feat: Add new sponsor Trupropel

### DIFF
--- a/content/la-meetup-2025/la-meetup/index.yaml
+++ b/content/la-meetup-2025/la-meetup/index.yaml
@@ -24,5 +24,6 @@ sponsors:
   - worldquant
   - nuuk
   - sicfe
+  - trupropel
 staff: []
 communities: []


### PR DESCRIPTION
### Summary
Trupropel continues as a sponsor for La Meetup III, extending their partnership from the successful 2024 event.

### Changes Made
- ✅ Added **Trupropel** to the sponsors list for La Meetup III
- 📄 Updated event configuration in `content/la-meetup-2025/la-meetup/index.yaml`