### PR TITLE
fix(agenda): update text color for agenda description for better readability

### DIFF
--- a/src/components/Meetups/2025/Agenda/index.tsx
+++ b/src/components/Meetups/2025/Agenda/index.tsx
@@ -67,7 +67,7 @@ export default function Agenda({ lastUpdate, agenda }: AgendaProps) {
     <section id="agenda" className="mt-16 w-full">
       <div className="mb-8 text-center">
         <h2 className="mb-4 text-4xl font-bold text-white md:text-5xl">Agenda</h2>
-        <p className="mx-auto max-w-2xl text-lg text-gray-400">¡Conocé el cronograma de actividades y charlas!</p>
+        <p className="mx-auto max-w-2xl text-lg text-gray-300">¡Conocé el cronograma de actividades y charlas!</p>
         {lastUpdate ? (
           <p className="mt-2 text-center text-xs text-gray-400">
             Última actualización: {format(parseISO(lastUpdate), "dd/MM/yyyy HH:mm:ss", { locale: es })}


### PR DESCRIPTION
This pull request includes a minor change to the `Agenda` component in the `src/components/Meetups/2025/Agenda/index.tsx` file. The text color for the agenda description has been slightly adjusted to improve readability.

* [`src/components/Meetups/2025/Agenda/index.tsx`](diffhunk://#diff-f2c8a4a66b24a89d814cf24b12ee98816bd1e541a89df3987c2e9508b77dd8f4L70-R70): Updated the text color of the agenda description from `text-gray-400` to `text-gray-300` for better contrast and visibility.