### PR TITLE
fix(agenda): update agenda description styling for improved readability

### DIFF
--- a/src/components/Meetups/2025/Agenda/index.tsx
+++ b/src/components/Meetups/2025/Agenda/index.tsx
@@ -67,7 +67,7 @@ export default function Agenda({ lastUpdate, agenda }: AgendaProps) {
     <section id="agenda" className="mt-16 w-full">
       <div className="mb-8 text-center">
         <h2 className="mb-4 text-4xl font-bold text-white md:text-5xl">Agenda</h2>
-        <p className="mx-auto max-w-2xl text-lg text-gray-300">¡Conocé el cronograma de actividades y charlas!</p>
+        <p className="mx-auto mt-2 max-w-3xl text-balance text-base leading-relaxed text-gray-300 lg:text-lg">¡Conocé el cronograma de actividades y charlas!</p>
         {lastUpdate ? (
           <p className="mt-2 text-center text-xs text-gray-400">
             Última actualización: {format(parseISO(lastUpdate), "dd/MM/yyyy HH:mm:ss", { locale: es })}


### PR DESCRIPTION
This pull request updates the styling and structure of the agenda description in the `Agenda` component to improve readability and alignment.

### Styling and structure improvements:

* [`src/components/Meetups/2025/Agenda/index.tsx`](diffhunk://#diff-f2c8a4a66b24a89d814cf24b12ee98816bd1e541a89df3987c2e9508b77dd8f4L70-R70): Adjusted the paragraph's maximum width, added a `text-balance` class, modified the font size and line height, and ensured consistent spacing with a `mt-2` margin for better readability.