### PR TITLE
feat(landing): improve spacing & typography, animate the community stats

### DIFF
--- a/src/components/Landing/Event/index.tsx
+++ b/src/components/Landing/Event/index.tsx
@@ -15,27 +15,22 @@ type EventProps = {
 
 export default function Event({ name, title, datetime, end_datetime, event_url }: EventProps) {
   return (
-    <li className="group flex w-full min-w-0 cursor-pointer gap-3 rounded-md bg-white/10 text-xs text-white sm:max-w-[550px] sm:text-base">
-      <Link className="w-full" href={addUtmParams(event_url)} target="_blank">
-        <div className="flex min-w-0 flex-1 flex-col justify-between gap-3 rounded-md bg-[#36393e] p-4 group-hover:bg-[#000214]/10">
-          <span className="flex flex-row items-center justify-between">
-            <span className="flex flex-col truncate">
-              <span className="truncate">{title}</span>
-              <span className="truncate text-xs text-zinc-400">{name}</span>
-            </span>
-            <p>
-              <time
-                className="hidden flex-col items-center justify-center rounded-xl border border-zinc-400 text-center text-xs capitalize sm:flex sm:min-h-[55px] sm:min-w-[55px] sm:text-sm"
-                dateTime={datetime}
-              >
-                {format(parseISO(datetime), "MMM", { locale: es })}
-                <br />
-                {format(parseISO(datetime), "dd", {
-                  locale: es,
-                })}
-              </time>
-            </p>
+    <li className="group w-full min-w-0 sm:max-w-[620px]">
+      <Link className="block" href={addUtmParams(event_url)} target="_blank">
+        <div className="flex min-w-0 items-center justify-between gap-4 rounded-xl border border-white/10 bg-[#2f3236] p-4 transition duration-200 group-hover:-translate-y-0.5 group-hover:border-yellow-400/40 group-hover:bg-[#36393e]">
+          <span className="flex min-w-0 flex-col">
+            <span className="truncate text-sm font-semibold sm:text-base">{title}</span>
+            <span className="truncate text-xs text-zinc-400 sm:text-sm">{name}</span>
           </span>
+          <time
+            className="hidden shrink-0 flex-col items-center justify-center rounded-lg border border-zinc-600 px-2 py-1.5 text-center capitalize sm:flex sm:min-h-[56px] sm:min-w-[56px]"
+            dateTime={datetime}
+          >
+            <span className="text-xs font-medium uppercase tracking-wide text-yellow-400">
+              {format(parseISO(datetime), "MMM", { locale: es })}
+            </span>
+            <span className="text-lg font-bold leading-none">{format(parseISO(datetime), "dd", { locale: es })}</span>
+          </time>
         </div>
       </Link>
     </li>

--- a/src/components/Landing/Events/index.tsx
+++ b/src/components/Landing/Events/index.tsx
@@ -3,6 +3,7 @@
 import { SectionKey } from "components/shared/Navbar/navSections";
 import { useNavigationContext } from "components/shared/Navbar/navigationProvider";
 import Event from "components/Landing/Event";
+import SectionHeading from "components/Landing/SectionHeading";
 
 type Event = {
   id: number;
@@ -23,15 +24,12 @@ export default function Events({ events }: EventsProps) {
   return (
     <section
       ref={sectionsRefs[SectionKey.Events]}
-      className="relative flex min-h-[500px] w-full flex-col items-center gap-8 self-center pt-20 text-white"
+      className="relative flex min-h-[500px] w-full flex-col items-center gap-12 self-center pb-12 pt-24 text-white sm:pt-28 lg:pt-32"
       id={SectionKey.Events}
     >
-      <span className="flex flex-col gap-1">
-        <h2 className="text-center text-3xl font-bold sm:text-4xl">Eventos de la comunidad</h2>
-        <h3 className="text-center text-zinc-400">¡Listado de próximos eventos!</h3>
-      </span>
+      <SectionHeading subtitle="¡Listado de próximos eventos!" title="Eventos de la comunidad" />
       {!!events?.length ? (
-        <ol className="flex w-full flex-col items-center justify-center gap-4 pb-4">
+        <ol className="flex w-full flex-col items-center justify-center gap-3">
           {events.map(({ id, name, title, datetime, end_datetime, event_url }) => (
             <Event
               key={id}
@@ -53,9 +51,9 @@ export default function Events({ events }: EventsProps) {
           </span>
         </div>
       )}
-      <div className="position absolute bottom-1 z-[-1] hidden w-full max-w-[1200px] flex-row items-end justify-between self-center xl:flex">
-        <img alt="Ilustración de una mujer" className="max-h-[380px]" src="/icons/girl.svg" />
-        <img alt="Ilustración de un hombre" className="max-h-[380px]" src="/icons/man.svg" />
+      <div className="absolute inset-x-0 bottom-0 z-[-1] mx-auto hidden w-full max-w-[1200px] flex-row items-end justify-between xl:flex">
+        <img alt="Ilustración de una mujer" className="block max-h-[380px]" src="/icons/girl.svg" />
+        <img alt="Ilustración de un hombre" className="block max-h-[380px]" src="/icons/man.svg" />
       </div>
     </section>
   );

--- a/src/components/Landing/Hero/index.tsx
+++ b/src/components/Landing/Hero/index.tsx
@@ -74,59 +74,59 @@ function Hero({
   return (
     <div
       ref={sectionsRefs[SectionKey.Hero]}
-      className="relative mx-auto min-h-[calc(100dvh-56px)] pt-16 sm:pt-32 lg:pt-5 2xl:pt-24"
+      className="relative mx-auto flex min-h-[calc(100dvh-56px)] w-full flex-col items-center justify-center px-4 pb-24 pt-12 text-primary sm:pt-16 lg:pb-28"
       id={SectionKey.Hero}
     >
-      <div className="flex h-full items-start justify-center bg-cover bg-center text-primary sm:items-center md:justify-around">
-        <div className="z-10 w-auto text-center">
-          <div className="flex flex-col items-center">
-            <div className="mb-12">
-              <p className="font-title text-5xl font-extrabold sm:text-5xl md:text-7xl xl:text-8xl">
-                <motion.span
-                  key={title}
-                  animate={{ opacity: 1, y: 0 }}
-                  className="inline-block text-yellow-400"
-                  initial={!isInitialWord ? { opacity: 0, y: 20 } : undefined}
-                  transition={{
-                    duration: 1,
-                    type: "spring",
-                    velocity: 2,
-                  }}
-                >
-                  {title}
-                </motion.span>
-              </p>
-              <span
-                className="font-title text-5xl font-extrabold text-white sm:text-5xl md:text-7xl xl:text-8xl"
-                style={{ width: "min-content" }}
-              >
-                {subtitle}
-              </span>
-              <p className="mx-auto mt-4 max-w-[640px] text-lg font-medium text-gray-300 md:text-[22px]">
-                {description}
-              </p>
-            </div>
-            <Link href={addUtmParams(slackButtonUrl ?? "#")} rel="noreferrer" target="_blank">
-              <button
-                className="text-md m-auto flex min-w-[220px] items-center justify-center rounded-md bg-white py-2 font-semibold text-black hover:bg-yellow-400 md:px-8 md:py-3"
-                type="button"
-              >
-                {slackButtonText}
-              </button>
-            </Link>
-            <div className="mt-5 flex w-full justify-center px-4 sm:px-0">
-              <UnpluggedTicket />
-            </div>
-            <Link
-              className="absolute bottom-2 flex flex-col items-center justify-center gap-2.5 self-center text-sm font-semibold text-white md:text-lg"
-              href={ctaButtonUrl ?? "#"}
+      <div className="z-10 flex w-full max-w-3xl flex-col items-center text-center">
+        <div className="flex flex-col items-center">
+          <p className="font-title text-[2.5rem] font-extrabold leading-[1.05] tracking-tight sm:text-6xl md:text-7xl xl:text-8xl">
+            <motion.span
+              key={title}
+              animate={{ opacity: 1, y: 0 }}
+              className="inline-block text-yellow-400"
+              initial={!isInitialWord ? { opacity: 0, y: 20 } : undefined}
+              transition={{
+                duration: 1,
+                type: "spring",
+                velocity: 2,
+              }}
             >
-              {ctaButtonText}
-              <FaChevronDown className="ml-3 animate-bounce" width="16px" />
-            </Link>
-          </div>
+              {title}
+            </motion.span>
+          </p>
+          {subtitle ? (
+            <span className="font-title text-[2.5rem] font-extrabold leading-[1.05] tracking-tight text-white sm:text-6xl md:text-7xl xl:text-8xl">
+              {subtitle}
+            </span>
+          ) : null}
+          <p className="mx-auto mt-5 max-w-[600px] text-balance text-base font-medium leading-relaxed text-zinc-300 sm:text-lg md:text-xl">
+            {description}
+          </p>
+        </div>
+        <Link
+          className="mt-10"
+          href={addUtmParams(slackButtonUrl ?? "#")}
+          rel="noreferrer"
+          target="_blank"
+        >
+          <button
+            className="inline-flex min-w-[220px] items-center justify-center rounded-lg bg-white px-8 py-3 text-base font-semibold text-black shadow-lg shadow-black/30 transition-all duration-200 hover:-translate-y-0.5 hover:bg-yellow-400 hover:shadow-yellow-400/20 active:translate-y-0"
+            type="button"
+          >
+            {slackButtonText}
+          </button>
+        </Link>
+        <div className="mt-10 flex w-full justify-center">
+          <UnpluggedTicket />
         </div>
       </div>
+      <Link
+        className="group absolute inset-x-0 bottom-6 mx-auto flex flex-col items-center justify-center gap-2 px-4 text-center text-xs font-semibold text-white/80 transition-colors hover:text-white sm:text-sm md:text-base"
+        href={ctaButtonUrl ?? "#"}
+      >
+        <span className="whitespace-nowrap">{ctaButtonText}</span>
+        <FaChevronDown className="animate-bounce" width="16px" />
+      </Link>
     </div>
   );
 }

--- a/src/components/Landing/SectionHeading/index.tsx
+++ b/src/components/Landing/SectionHeading/index.tsx
@@ -1,0 +1,16 @@
+type SectionHeadingProps = {
+  title: string;
+  subtitle?: string;
+};
+
+export default function SectionHeading({ title, subtitle }: SectionHeadingProps) {
+  return (
+    <div className="flex flex-col items-center gap-3 text-center">
+      <h2 className="font-title text-3xl font-bold leading-tight tracking-tight text-white sm:text-4xl md:text-5xl">
+        {title}
+      </h2>
+      <span aria-hidden className="h-1 w-12 rounded-full bg-yellow-400" />
+      {subtitle ? <p className="max-w-xl text-balance text-sm text-zinc-400 sm:text-base">{subtitle}</p> : null}
+    </div>
+  );
+}

--- a/src/components/Landing/Stat/index.tsx
+++ b/src/components/Landing/Stat/index.tsx
@@ -1,15 +1,54 @@
+"use client";
+
+import { animate, motion, useMotionValue, useReducedMotion, useTransform } from "motion/react";
+import { useEffect } from "react";
+
 type StatProps = {
   title: string;
   count: number | null;
   subtitle: string;
+  play?: boolean;
+  index?: number;
 };
 
-export default function Stat({ title, count, subtitle }: StatProps) {
+export default function Stat({ title, count, subtitle, play = false, index = 0 }: StatProps) {
+  const target = count ?? 0;
+  const prefersReducedMotion = useReducedMotion();
+
+  const motionCount = useMotionValue(0);
+  const display = useTransform(motionCount, (latest) => `+${Math.round(latest)}`);
+
+  useEffect(() => {
+    if (!play) return;
+
+    if (prefersReducedMotion) {
+      motionCount.set(target);
+      return;
+    }
+
+    const controls = animate(motionCount, target, {
+      duration: 2,
+      delay: index * 0.15,
+      ease: [0.16, 1, 0.3, 1],
+    });
+
+    return () => controls.stop();
+  }, [play, target, index, prefersReducedMotion, motionCount]);
+
   return (
-    <div className="text-center text-white">
-      <p className="text-4xl font-bold text-yellow-400">+{count}</p>
-      <p className="text-2xl font-semibold">{title}</p>
-      <p className="text-base">{subtitle}</p>
+    <div className="flex flex-col items-center gap-1 text-center text-white">
+      <p className="font-title text-4xl font-extrabold tabular-nums text-yellow-400 sm:text-5xl">
+        {/* The invisible ghost reserves the final width so the box never resizes (no layout shift);
+            the animated value overlays it left-anchored so the "+" stays pinned (no digit-jump jitter). */}
+        <span className="relative inline-block text-left">
+          <span aria-hidden className="invisible">
+            +{target}
+          </span>
+          <motion.span className="absolute left-0 top-0">{display}</motion.span>
+        </span>
+      </p>
+      <p className="text-lg font-semibold leading-tight sm:text-xl">{title}</p>
+      <p className="text-sm text-zinc-400">{subtitle}</p>
     </div>
   );
 }

--- a/src/components/Landing/Stats/index.tsx
+++ b/src/components/Landing/Stats/index.tsx
@@ -1,6 +1,10 @@
 "use client";
+import { useInView } from "motion/react";
+import { useRef } from "react";
+
 import { SectionKey } from "components/shared/Navbar/navSections";
 import { useNavigationContext } from "components/shared/Navbar/navigationProvider";
+import SectionHeading from "components/Landing/SectionHeading";
 
 import Stat from "../Stat";
 
@@ -14,27 +18,33 @@ type StatsProps = {
 
 export default function Stats({ stats }: StatsProps) {
   const { sectionsRefs } = useNavigationContext();
+  const statsGridRef = useRef<HTMLDivElement>(null);
+  const statsInView = useInView(statsGridRef, { once: true, amount: 0.3 });
 
   return (
     <section
       ref={sectionsRefs[SectionKey.Stats]}
-      className="flex w-full flex-col items-center justify-center gap-12 pt-20"
+      className="flex w-full flex-col items-center gap-12 pt-24 sm:pt-28 lg:pt-32"
       id={SectionKey.Stats}
     >
-      <span className="flex flex-col gap-1">
-        <h2 className="text-center text-4xl font-semibold text-white">Nuestra comunidad en cifras</h2>
-        <h3 className="text-center text-zinc-400">¡Creciendo juntos, nuestra comunidad en números!</h3>
-      </span>
-      <div className="grid w-full place-items-center gap-5 xl:grid-cols-[1fr_550px]">
+      <SectionHeading subtitle="¡Creciendo juntos, nuestra comunidad en números!" title="Nuestra comunidad en cifras" />
+      <div className="grid w-full place-items-center gap-10 xl:grid-cols-[1fr_550px] xl:gap-8">
         <img
           alt="Ilustración de un carpincho"
           className="w-full min-w-[280px] max-w-[600px] self-center object-contain"
           src="/icons/community.svg"
         />
         {stats ? (
-          <div className="grid grid-cols-2 place-items-center gap-16">
-            {stats.map(({ title, subtitle, count }) => (
-              <Stat key={`${title}-${subtitle}`} count={count} subtitle={subtitle} title={title} />
+          <div ref={statsGridRef} className="grid grid-cols-2 place-items-center gap-x-10 gap-y-12 sm:gap-x-16">
+            {stats.map(({ title, subtitle, count }, index) => (
+              <Stat
+                key={`${title}-${subtitle}`}
+                count={count}
+                index={index}
+                play={statsInView}
+                subtitle={subtitle}
+                title={title}
+              />
             ))}
           </div>
         ) : (

--- a/src/components/Landing/Story/index.tsx
+++ b/src/components/Landing/Story/index.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { SectionKey } from "components/shared/Navbar/navSections";
 import { useNavigationContext } from "components/shared/Navbar/navigationProvider";
 import { RichText } from "components/shared/RichText";
+import SectionHeading from "components/Landing/SectionHeading";
 
 type StoryProps = {
   content?: unknown;
@@ -16,28 +17,26 @@ export default function Story({ content, image }: StoryProps) {
   return (
     <section
       ref={sectionsRefs[SectionKey.Story]}
-      className="flex w-full flex-col justify-center gap-8 self-center pt-20 text-white"
+      className="flex w-full flex-col gap-12 pt-24 text-white sm:pt-28 lg:pt-32"
       id={SectionKey.Story}
     >
-      <span className="flex flex-col gap-1">
-        <h2 className="text-center text-3xl font-bold sm:text-4xl">¿Qué es OWU Uruguay?</h2>
-        <h3 className="text-center text-zinc-400">Nuestra Historia</h3>
-      </span>
-      <span className="grid place-items-center md:grid-cols-[1fr_500px]">
-        <div className="flex w-full flex-col gap-4">
+      <SectionHeading subtitle="Nuestra Historia" title="¿Qué es OWU Uruguay?" />
+      <div className="grid items-center gap-10 md:grid-cols-[1fr_420px] lg:gap-16 xl:grid-cols-[1fr_480px]">
+        <div className="richtext flex w-full max-w-[60ch] flex-col gap-4 text-base leading-relaxed text-zinc-300">
           <RichText content={content as string} />
         </div>
-        <div className="flex min-h-[400px] w-full flex-col items-center justify-end xl:items-end">
-          <span className="relative min-h-[400px] w-full max-w-[400px]">
+        <div className="flex w-full justify-center md:justify-end">
+          <span className="relative aspect-square w-full max-w-[420px]">
             <Image
               fill
-              alt="ilustración de un carpincho"
-              className="w-full max-w-[400px] object-contain"
+              alt="Ilustración de un carpincho"
+              className="object-contain"
+              sizes="(max-width: 768px) 80vw, 420px"
               src={image ?? ""}
             />
           </span>
         </div>
-      </span>
+      </div>
     </section>
   );
 }

--- a/src/components/shared/Footer/index.tsx
+++ b/src/components/shared/Footer/index.tsx
@@ -35,9 +35,9 @@ export default function Footer() {
   ];
 
   return (
-    <footer className="w-full border-t border-zinc-500 px-4 sm:px-6 lg:px-8 xl:px-0">
-      <div className="flex flex-col justify-between py-8 text-center text-white lg:flex-row">
-        <ul className="flex flex-col gap-4 pb-8 text-sm font-[550] sm:text-base md:pb-3 lg:flex-row lg:pb-0 lg:text-left">
+    <footer className="w-full border-t border-white/10 px-4 sm:px-6 lg:px-8 xl:px-0">
+      <div className="flex flex-col items-center justify-between gap-6 py-10 text-center text-white lg:flex-row lg:gap-4">
+        <ul className="flex flex-col gap-4 text-sm font-[550] sm:text-base lg:flex-row lg:gap-6 lg:text-left">
           {LINKS.map(({ href, label, external }) => (
             <li key={href} className="hover:text-yellow-400">
               <Link

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,7 @@ const config = {
     "./components/**/*.{ts,tsx}",
     "./app/**/*.{ts,tsx}",
     "./src/**/*.{ts,tsx}",
-    "*.{svg}",
+    "*.svg",
   ],
   prefix: "",
   theme: {
@@ -22,6 +22,7 @@ const config = {
       fontFamily: {
         pixel: ['"Press Start 2P"', "monospace"],
         display: ["Poppins", "sans-serif"],
+        title: ["Poppins", "sans-serif"],
         terminal: ['"Geist Mono"', "ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
       },
       colors: {


### PR DESCRIPTION
This pull request is a design pass on the landing page (`/`): it tightens spacing and vertical rhythm, unifies the section typography, rebalances the hero, and adds an animated count-up to the community stats. No new dependencies are introduced — the count-up reuses `motion/react`, which the hero already relies on.

### Spacing & layout

* `src/components/Landing/Hero/index.tsx`: Centers the hero vertically with a `flex` / `justify-center` column (fixes an `h-full`-against-`min-height` bug that left a dead void above the scroll cue), moves to gap-based rhythm, refines the CTA button, and keeps the scroll cue on a single line at every width.
* `src/components/Landing/Events/index.tsx`, `src/components/Landing/Event/index.tsx`: Standardize the section spacing, widen the event cards (560 → 620px), polish the hover state and date badge, and seat the flanking illustrations flush on the footer border.
* `src/components/shared/Footer/index.tsx`: Tidies the footer spacing and aligns its top border with the section above.

### Typography & hierarchy

* `tailwind.config.ts`: Registers `font-title` → Poppins (it was referenced in the hero but never defined, so it silently fell back to Inter) and fixes the invalid `*.{svg}` content glob.
* `src/components/Landing/SectionHeading/index.tsx`: New shared heading (Poppins title + accent bar + muted subtitle), applied across Story, Stats, and Events, which previously each used a different size/weight/font.
* `src/components/Landing/Story/index.tsx`: Adopts `SectionHeading`, constrains the text column width for readability, and adds the missing `sizes` prop to the `next/image`.

### Animated community stats (cifras)

* `src/components/Landing/Stat/index.tsx`: Counts each metric up from 0 with `motion/react` and an ease-out curve. An invisible ghost reserves the final width and the value is left-anchored, so the count-up has **no layout shift and no digit jitter**; it also respects `prefers-reduced-motion` (snaps to the final value).
* `src/components/Landing/Stats/index.tsx`: Adopts `SectionHeading` and triggers the whole group once the grid scrolls into view (with a subtle per-item stagger), so the bottom row always animates — even when the section is reached via the "Estadísticas" anchor.

> [!NOTE]
> No deployment actions or environment variables are required. The motion and spacing are easiest to review on the Vercel preview — scroll to **Estadísticas** to see the count-up.
