### PR TITLE
fix(seo): conf.owu.uy sharing the wrong Open Graph image

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,8 +10,17 @@ import { Toaster } from "components/shared/ui/sonner";
 import { EXTERNAL_SERVICES } from "./lib/constants";
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://www.owu.uy"),
   description: "Únete a nuestra comunidad de desarrolladores.",
   title: "OWU | Comunidad TI de Uruguay",
+  openGraph: {
+    type: "website",
+    images: ["/images/events/la_meetup_2024.png"],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["/images/events/la_meetup_2024.png"],
+  },
 };
 
 export default function RootLayout({
@@ -21,11 +30,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="es">
-      <meta charSet="utf-8" />
-      <meta content="website" property="og:type" />
-      <meta content="/images/events/la_meetup_2024.png" property="og:image" />
-      <meta content="summary_large_image" property="twitter:card" />
-      <meta content="/images/events/la_meetup_2024.png" property="twitter:image" />
       <Analytics />
       <SpeedInsights />
       <Script async src={EXTERNAL_SERVICES.googleTagManager} />


### PR DESCRIPTION
## Problem

Sharing https://conf.owu.uy anywhere (WhatsApp/Slack/X/LinkedIn) shows the **La Meetup 2024** image instead of the OWU CONF card added in #173.

## Cause

`src/app/layout.tsx` rendered hardcoded raw `<meta property="og:image">` / `twitter:image` tags as JSX children of `<html>`. React hoists those into `<head>` **ahead of** the tags generated by the Next.js metadata API, so every page shipped **two** `og:image` tags:

```html
<meta content="/images/events/la_meetup_2024.png" property="og:image"/>  <!-- first: wins -->
<meta property="og:image" content="https://conf.owu.uy/images/conf/og.png"/> <!-- ours: ignored -->
```

Scrapers take the first `og:image` in the document, so the conf card never won. The hardcoded default was also a **relative** URL, which is invalid Open Graph on its own.

## Fix

Moved the site-wide social defaults into the root layout's `metadata` export (with `metadataBase: https://owu.uy`) and deleted the raw tags. Result:

- Pages with their own `openGraph`/`twitter` metadata (the conf pages) now emit a **single** `og:image` — the OWU CONF card.
- Every other page keeps the 2024 default, now resolved to an **absolute** URL.

## Verified

- `tsc` clean.
- `curl -H "Host: conf.owu.uy" localhost:3000/` → one `og:image`: `https://conf.owu.uy/images/conf/og.png` (+ width/height/alt).
- `curl localhost:3000/` → one `og:image`: `https://owu.uy/images/events/la_meetup_2024.png`.

## Post-merge note

WhatsApp/Facebook cache scraped cards aggressively — after deploy, force a re-scrape with the [Sharing Debugger](https://developers.facebook.com/tools/debug/) (and equivalents) for `https://conf.owu.uy`.