### PR TITLE
ci(deps): group dependabot updates and auto-merge non-major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,104 @@
 version: 2
+
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "America/Montevideo"
+    labels:
+      - dependencies
+    # why: supply-chain cooldown — skip freshly published releases until compromised versions are typically detected and unpublished
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:00"
       timezone: "America/Montevideo"
-    open-pull-requests-limit: 5
-    target-branch: development
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
     labels:
       - dependencies
+    # why: supply-chain cooldown — skip freshly published releases until compromised versions are typically detected and unpublished
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
+    groups:
+      framework:
+        patterns:
+          - "next"
+          - "@next/*"
+          - "eslint-config-next"
+          - "react"
+          - "react-dom"
+        update-types:
+          - "minor"
+          - "patch"
+      remotion:
+        patterns:
+          - "remotion"
+          - "@remotion/*"
+      orpc:
+        patterns:
+          - "@orpc/*"
+      drizzle:
+        patterns:
+          - "drizzle-orm"
+          - "drizzle-kit"
+      ai:
+        patterns:
+          - "ai"
+          - "@ai-sdk/*"
+      keystatic:
+        patterns:
+          - "@keystatic/*"
+      ui:
+        patterns:
+          - "@radix-ui/*"
+          - "lucide-react"
+          - "class-variance-authority"
+          - "clsx"
+          - "tailwind-merge"
+          - "cmdk"
+          - "sonner"
+          - "next-themes"
+          - "embla-carousel-*"
+      forms:
+        patterns:
+          - "react-hook-form"
+          - "@hookform/*"
+          - "zod"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      styling:
+        patterns:
+          - "tailwindcss"
+          - "tailwindcss-animate"
+          - "postcss"
+      tooling:
+        dependency-type: "development"
+        patterns:
+          - "eslint*"
+          - "prettier*"
+          - "@typescript-eslint/*"
+          - "@vercel/style-guide"
+          - "typescript"
+          - "tsx"
+          - "cross-env"
+          - "@svgr/webpack"
+        exclude-patterns:
+          - "eslint-config-next"
+      types:
+        patterns:
+          - "@types/*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,80 @@
+name: Dependabot Auto-Merge
+
+on:
+  workflow_run:
+    workflows: ["Create vercel preview URL on pull request"]
+    types: [completed]
+
+concurrency:
+  group: dependabot-auto-merge
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+jobs:
+  auto-merge:
+    name: Auto-Merge
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
+    steps:
+      - name: Get PR number
+        id: pr
+        run: |
+          PR_NUMBER=$(gh api -X GET "repos/$REPO/pulls" -f head="$HEAD_OWNER:$HEAD_BRANCH" -f state=open \
+            --jq '[.[] | select(.user.login == "dependabot[bot]")][0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open Dependabot PR for $HEAD_BRANCH — nothing to do."
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+        env:
+          REPO: ${{ github.repository }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check update type
+        id: update-type
+        if: steps.pr.outputs.number != ''
+        # Dependabot embeds machine-readable metadata in its commit messages
+        # (updated-dependencies / update-type), which also covers grouped PRs —
+        # PR titles of grouped updates carry no version info, so titles can't be
+        # trusted for major detection. Unclassifiable PRs are never merged.
+        run: |
+          COMMITS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --jq '.[].commit.message')
+          if ! echo "$COMMITS" | grep -q 'updated-dependencies:'; then
+            echo "No Dependabot metadata found — leaving for manual review."
+            echo "mergeable=false" >> "$GITHUB_OUTPUT"
+          elif echo "$COMMITS" | grep -q 'version-update:semver-major'; then
+            echo "Contains a major version bump — leaving for manual review."
+            echo "mergeable=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "mergeable=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge PR
+        if: steps.update-type.outputs.mergeable == 'true'
+        run: gh pr merge --squash "$PR_NUMBER" --repo "$REPO" --match-head-commit "$HEAD_SHA"
+        env:
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger production deploy
+        if: steps.update-type.outputs.mergeable == 'true'
+        # Pushes made with GITHUB_TOKEN don't fire push-triggered workflows, so
+        # the merge above won't start "Deploy to vercel on merge" by itself.
+        run: gh workflow run vercel-merge.yml --ref main --repo "$REPO"
+        env:
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vercel-merge.yml
+++ b/.github/workflows/vercel-merge.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### How I solved it:

**1. Reworked `.github/dependabot.yml`** (github-actions + npm, daily 09:00 America/Montevideo):

- Supply-chain cooldowns: 7d default, and 30/14/7d for major/minor/patch on npm, so freshly published releases are skipped until compromised versions are typically detected and unpublished.
- Grouped updates matched to this repo's actual dependency families: `framework` (next/@next/react, minor+patch only), `remotion` (all pinned in lockstep), `orpc`, `drizzle`, `ai`, `keystatic`, `ui` (radix + shadcn companions), `forms`, `tanstack`, `styling`, `tooling` (eslint/prettier stack), `types`.
- Removed `target-branch: development` — that branch doesn't exist on the remote (Dependabot errors on a missing target branch), so PRs now target `main`.

**2. Added `.github/workflows/dependabot-auto-merge.yml`** — merges Dependabot PRs automatically once the Vercel preview build succeeds, majors excluded:

- Triggers on completion of "Create vercel preview URL on pull request" and only for runs initiated by `dependabot[bot]`.
- Major-version detection reads Dependabot's machine-readable commit metadata (`update-type: version-update:semver-major`) instead of parsing PR titles — grouped PR titles carry no version info. Unclassifiable PRs are never merged (fail-safe).
- `--match-head-commit` guarantees only the exact commit CI validated gets merged (no race with a Dependabot rebase).
- No approve step: the repo has "Allow GitHub Actions to approve pull requests" disabled and `main` has no review requirement, so it would fail without adding value.
- Hardened against workflow injection: all event data (`head_branch`, etc.) is passed via `env:` vars, URL params go through `gh api -f`.

**3. Added `workflow_dispatch:` to `vercel-merge.yml`** — merges performed with `GITHUB_TOKEN` don't fire push-triggered workflows, and the Vercel Git integration is disabled in `vercel.json`, so without this the auto-merged PRs would land on `main` but never deploy to production. The auto-merge workflow dispatches the prod deploy explicitly after merging.

---

#### Checklist:

- [ ] I've added unit tests. _(N/A — CI/config only)_
- [x] I've added inline documentation when the code is not trivial.
- [ ] I've updated the project documentation.
- [x] I've not used acronyms for file or variable names.
- [x] I've explicitly indicated if this PR needs deployment actions: **none** — uses the existing `GITHUB_TOKEN`, no new secrets or settings required.

---

#### Screenshots:

N/A

---

#### API expected request/response:

N/A

---

#### Refactors or changes not directly related to the main purpose of this PR:

None.
