### PR TITLE
feat(conf): add timezone-agnostic countdowns for the event and deadlines

### DIFF
--- a/src/app/conf/call-for-proposals/page.tsx
+++ b/src/app/conf/call-for-proposals/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 
-import { EXTERNAL_SERVICES, INTERNAL_ROUTES } from "app/lib/constants";
+import { CONF_DATES, EXTERNAL_SERVICES, INTERNAL_ROUTES } from "app/lib/constants";
 
+import Countdown from "../components/Countdown";
 import Footer from "../components/Footer";
 import FormEmbed from "../components/FormEmbed";
 import MotionRoot from "../components/MotionRoot";
@@ -81,6 +82,10 @@ export default function CallForProposalsPage() {
                   Fecha límite para enviar propuestas:{" "}
                   <strong className="font-display font-bold uppercase text-[#F5BB03]">15 de septiembre</strong>
                 </p>
+              </Reveal>
+
+              <Reveal delay={0.3} y={18}>
+                <Countdown className="mt-6" expiredLabel="CONVOCATORIA CERRADA" target={CONF_DATES.cfpDeadline} />
               </Reveal>
 
               <Reveal delay={0.32} y={20}>

--- a/src/app/conf/components/Countdown.tsx
+++ b/src/app/conf/components/Countdown.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import classNames from "classnames";
+import { useEffect, useState } from "react";
+
+type Remaining = {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  expired: boolean;
+};
+
+/* Sized so a row of four cells fits a 360px viewport inside the page's px-8 gutters */
+const SIZES = {
+  sm: {
+    row: "gap-1.5 sm:gap-2",
+    height: "h-14 sm:h-16",
+    width: "w-14 sm:w-16",
+    number: "text-xl sm:text-2xl",
+    expired: "text-lg",
+  },
+  lg: {
+    row: "gap-1.5 sm:gap-3",
+    height: "h-14 sm:h-24",
+    width: "w-14 sm:w-24",
+    number: "text-xl sm:text-4xl",
+    expired: "text-lg sm:text-2xl",
+  },
+} as const;
+
+function getRemaining(targetMs: number): Remaining {
+  const diff = targetMs - Date.now();
+  const left = Math.max(0, diff);
+
+  return {
+    days: Math.floor(left / 86_400_000),
+    hours: Math.floor(left / 3_600_000) % 24,
+    minutes: Math.floor(left / 60_000) % 60,
+    seconds: Math.floor(left / 1_000) % 60,
+    expired: diff <= 0,
+  };
+}
+
+type CountdownProps = {
+  /** ISO 8601 with an explicit UTC offset (e.g. "2026-09-15T23:59:59-03:00"): an absolute instant, so every timezone sees the same remaining time */
+  target: string;
+  /** Replaces the cells once the target passes */
+  expiredLabel: string;
+  size?: keyof typeof SIZES;
+  /** Cells stretch to fill the container instead of keeping their fixed square width */
+  fullWidth?: boolean;
+  className?: string;
+};
+
+/*
+ * The conf pages are statically rendered, so the remaining time only exists on the
+ * client: zeros on the server pass, real values from the mount effect onwards. The
+ * surrounding <Reveal> fade masks the swap.
+ */
+export default function Countdown({
+  target,
+  expiredLabel,
+  size = "sm",
+  fullWidth = false,
+  className,
+}: CountdownProps) {
+  const [remaining, setRemaining] = useState<Remaining | null>(null);
+  const sizes = SIZES[size];
+
+  useEffect(() => {
+    const targetMs = new Date(target).getTime();
+    const update = () => setRemaining(getRemaining(targetMs));
+
+    update();
+    const id = setInterval(update, 1000);
+
+    return () => clearInterval(id);
+  }, [target]);
+
+  if (remaining?.expired) {
+    return (
+      <p
+        className={classNames(
+          "font-display font-bold uppercase leading-none text-[#F5BB03]",
+          sizes.expired,
+          className
+        )}
+      >
+        {expiredLabel}
+      </p>
+    );
+  }
+
+  const units = [
+    { key: "days", value: remaining?.days, label: remaining?.days === 1 ? "DÍA" : "DÍAS", solid: true },
+    { key: "hours", value: remaining?.hours, label: remaining?.hours === 1 ? "HORA" : "HORAS", solid: false },
+    { key: "minutes", value: remaining?.minutes, label: "MIN", solid: false },
+    { key: "seconds", value: remaining?.seconds, label: "SEG", solid: false },
+  ];
+
+  return (
+    /* Hidden from screen readers: the copy beside each placement carries the date, and a timer re-announcing itself every second is pure noise */
+    <div aria-hidden="true" className={classNames("flex", sizes.row, fullWidth && "w-full", className)}>
+      {units.map(({ key, value, label, solid }) => (
+        <div
+          key={key}
+          className={classNames(
+            "flex flex-col items-center justify-center",
+            sizes.height,
+            fullWidth ? "flex-1" : `shrink-0 ${sizes.width}`,
+            solid ? "bg-[#F5BB03] text-black" : "border-2 border-[#FBF5E7]/15 text-[#FBF5E7]"
+          )}
+        >
+          <span className={classNames("font-display font-extrabold leading-none tabular-nums", sizes.number)}>
+            {String(value ?? 0).padStart(2, "0")}
+          </span>
+          <span
+            className={classNames(
+              "mt-1 font-display text-[10px] font-bold uppercase tracking-[0.14em]",
+              !solid && "text-[#FBF5E7]/50"
+            )}
+          >
+            {label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/conf/components/Hero.tsx
+++ b/src/app/conf/components/Hero.tsx
@@ -2,8 +2,9 @@
 
 import { m } from "motion/react";
 
-import { INTERNAL_ROUTES, MAPS_URLS } from "app/lib/constants";
+import { CONF_DATES, INTERNAL_ROUTES, MAPS_URLS } from "app/lib/constants";
 
+import Countdown from "./Countdown";
 import PillLink from "./PillLink";
 import { EASE_OUT } from "./Reveal";
 
@@ -72,12 +73,22 @@ export default function Hero() {
           </a>
         </m.div>
 
-        <m.div className="mt-8 flex flex-wrap items-center justify-center gap-4 sm:justify-start" {...contentEntrance(2)}>
-          <PillLink href={INTERNAL_ROUTES.conf.callForProposals}>¡POSTULAR MI CHARLA!</PillLink>
-          <PillLink href={INTERNAL_ROUTES.conf.sponsors} variant="outline">
-            ¡QUIERO SER SPONSOR!
-          </PillLink>
-        </m.div>
+        {/* w-fit is measured by the CTA row, so the countdown below stretches to exactly the buttons' width */}
+        <div className="mx-auto w-fit sm:mx-0">
+          <m.div {...contentEntrance(2)}>
+            <Countdown className="mt-8" expiredLabel="¡LLEGÓ EL DÍA!" fullWidth target={CONF_DATES.event} />
+          </m.div>
+
+          <m.div
+            className="mt-8 flex flex-wrap items-center justify-center gap-4 sm:justify-start"
+            {...contentEntrance(3)}
+          >
+            <PillLink href={INTERNAL_ROUTES.conf.callForProposals}>¡POSTULAR MI CHARLA!</PillLink>
+            <PillLink href={INTERNAL_ROUTES.conf.sponsors} variant="outline">
+              ¡QUIERO SER SPONSOR!
+            </PillLink>
+          </m.div>
+        </div>
 
         {/* Right edge aligns with the navbar content line (inner px-8 edge); desktop LCP image */}
         <m.img

--- a/src/app/conf/components/Speakers.tsx
+++ b/src/app/conf/components/Speakers.tsx
@@ -3,8 +3,9 @@
 import classNames from "classnames";
 import { useCallback, useState } from "react";
 
-import { INTERNAL_ROUTES } from "app/lib/constants";
+import { CONF_DATES, INTERNAL_ROUTES } from "app/lib/constants";
 
+import Countdown from "./Countdown";
 import Lightbox, { openWithMorph, withViewTransition, type LightboxPhoto } from "./Lightbox";
 import PillLink from "./PillLink";
 import Reveal from "./Reveal";
@@ -71,12 +72,23 @@ export default function Speakers() {
               ¡POSTULAR MI CHARLA!
             </PillLink>
           </Reveal>
-          <Reveal className="max-sm:text-center" delay={0.44} y={14}>
-            <p className="mt-4 text-sm text-[#FBF5E7]/60">
-              Fecha límite para enviar propuestas:{" "}
-              <strong className="font-semibold text-[#F5BB03]">15 de septiembre</strong>
-            </p>
-          </Reveal>
+          {/* w-fit is measured by the deadline line, so the countdown below stretches to exactly its width */}
+          <div className="mx-auto w-fit sm:mx-0">
+            <Reveal className="max-sm:text-center" delay={0.44} y={14}>
+              <p className="mt-4 text-sm text-[#FBF5E7]/60">
+                Fecha límite para enviar propuestas:{" "}
+                <strong className="font-semibold text-[#F5BB03]">15 de septiembre</strong>
+              </p>
+            </Reveal>
+            <Reveal delay={0.54} y={14}>
+              <Countdown
+                className="mt-5"
+                expiredLabel="CONVOCATORIA CERRADA"
+                fullWidth
+                target={CONF_DATES.cfpDeadline}
+              />
+            </Reveal>
+          </div>
         </div>
 
         <Reveal amount={0.3} className="hidden w-full max-w-[480px] shrink-0 md:block" delay={0.15} x={48} y={0}>

--- a/src/app/conf/components/Sponsors.tsx
+++ b/src/app/conf/components/Sponsors.tsx
@@ -1,5 +1,6 @@
-import { INTERNAL_ROUTES } from "app/lib/constants";
+import { CONF_DATES, INTERNAL_ROUTES } from "app/lib/constants";
 
+import Countdown from "./Countdown";
 import PillLink from "./PillLink";
 import Reveal from "./Reveal";
 import SectionHeader from "./SectionHeader";
@@ -38,6 +39,25 @@ export default function Sponsors() {
           <PillLink href={INTERNAL_ROUTES.conf.sponsors}>¡QUIERO SER SPONSOR!</PillLink>
         </Reveal>
       </div>
+
+      <Reveal delay={0.15} y={20}>
+        <div className="mt-12 flex flex-col gap-8 border-2 border-[#FBF5E7]/15 p-5 sm:p-8 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="font-display text-xs font-semibold uppercase leading-none tracking-[0.18em] text-[#FBF5E7]/60">
+              Aceptamos postulaciones
+            </p>
+            <p className="mt-3 text-balance font-display text-2xl font-extrabold uppercase leading-none tracking-[-0.02em] text-[#F5BB03] sm:text-3xl">
+              Hasta el 15 de septiembre
+            </p>
+          </div>
+          <Countdown
+            className="shrink-0"
+            expiredLabel="CONVOCATORIA CERRADA"
+            size="lg"
+            target={CONF_DATES.sponsorsDeadline}
+          />
+        </div>
+      </Reveal>
 
       <Reveal delay={0.1} y={16}>
         <p className="mt-14 font-display text-xs font-semibold uppercase tracking-[0.18em] text-[#FBF5E7]/60">

--- a/src/app/conf/sponsors/page.tsx
+++ b/src/app/conf/sponsors/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 
-import { EXTERNAL_SERVICES, INTERNAL_ROUTES } from "app/lib/constants";
+import { CONF_DATES, EXTERNAL_SERVICES, INTERNAL_ROUTES } from "app/lib/constants";
 
+import Countdown from "../components/Countdown";
 import Footer from "../components/Footer";
 import FormEmbed from "../components/FormEmbed";
 import MotionRoot from "../components/MotionRoot";
@@ -105,6 +106,14 @@ export default function SponsorsFormPage() {
                   Dejanos tus datos y te enviamos el brochure de sponsorship con los beneficios y todos los
                   detalles.
                 </p>
+              </Reveal>
+
+              <Reveal delay={0.48} y={18}>
+                <p className="mt-10 font-display text-xs font-semibold uppercase leading-none tracking-[0.18em] text-[#FBF5E7]/60">
+                  Aceptamos postulaciones hasta el{" "}
+                  <strong className="text-[#F5BB03]">15 de septiembre</strong>
+                </p>
+                <Countdown className="mt-4" expiredLabel="CONVOCATORIA CERRADA" target={CONF_DATES.sponsorsDeadline} />
               </Reveal>
             </div>
 

--- a/src/app/lib/constants/index.ts
+++ b/src/app/lib/constants/index.ts
@@ -25,6 +25,14 @@ export const EVENT_DATES = {
   meetup2025: new Date("2025-11-01T00:00:00"),
 } as const;
 
+// OWU CONF 2026 — ISO 8601 with an explicit -03:00 (Uruguay) offset: absolute instants,
+// so countdowns resolve to the same moment in every visitor's timezone
+export const CONF_DATES = {
+  cfpDeadline: "2026-09-15T23:59:59-03:00",
+  sponsorsDeadline: "2026-09-15T23:59:59-03:00",
+  event: "2026-11-07T14:30:00-03:00",
+} as const;
+
 // OpenSpace Room Colors
 export const ROOM_COLORS = {
   LOBBY: "#03A9F4",


### PR DESCRIPTION
#### How I solved it:

Adds a `Countdown` client component to the OWU CONF pages and wires it into five places.

**Timezone-agnostic by construction.** Each target lives in a new `CONF_DATES` constant as an ISO 8601 string with an explicit `-03:00` (Uruguay) offset — an absolute instant, not a wall-clock time. The component computes `target - Date.now()` on the client, so a visitor in Tokyo, Madrid or Montevideo sees the exact same remaining time. This follows the pattern already used in `src/contexts/TicketReleaseContext.tsx`.

```ts
export const CONF_DATES = {
  cfpDeadline: "2026-09-15T23:59:59-03:00",
  sponsorsDeadline: "2026-09-15T23:59:59-03:00",
  event: "2026-11-07T14:30:00-03:00",
} as const;
```

**Why client-side.** `/conf` is statically prerendered with hourly ISR and the two form pages are fully static, so a countdown rendered on the server would bake stale numbers into the HTML. State starts neutral and the real value is computed in a mount effect — the repo's existing idiom — so there is no hydration mismatch. The surrounding `<Reveal>` fade covers the one-frame swap.

**Design.** Four sharp-edged cells (`DÍAS / HORAS / MIN / SEG`) with the days cell in solid `#F5BB03` and black text, echoing the meetup date chip in `Meetups.tsx`. Digits are `tabular-nums` and zero-padded so nothing shifts while ticking. The ticking row is `aria-hidden` — a timer re-announcing itself every second is noise for screen readers, and every placement sits beside human-readable date copy that carries the information.

**Placements:**

| Location | Counts down to |
| --- | --- |
| Hero | Event — 07/11/2026 14:30 UY |
| Speakers section | CFP deadline — 15/09/2026 23:59:59 UY |
| Call for Proposals page | CFP deadline |
| Sponsors section | Sponsorship deadline — same instant |
| Sponsors page | Sponsorship deadline |

Widths are derived, not hardcoded: the hero and Speakers countdowns sit in a `w-fit` wrapper shared with the element they should match (the CTA button row and the deadline line respectively), so they stretch to exactly that width and stay aligned if the copy ever changes.

---

#### Checklist:

- [ ] I've added unit tests.  <!-- the repo has no test runner or test files; nothing to hook into -->
- [x] I've added inline documentation when the code is not trivial.
- [ ] I've updated the project [documentation](https://github.com/owu-uy/owu/blob/production/readme.md).  <!-- no docs cover the conf landing sections -->
- [x] I've not used acronyms for file or variable names.
- [x] I've explicitly indicated if this PR needs deployment actions (e.g: Env variables).  <!-- none needed -->

---

#### Screenshots:

_To be attached — please add captures of the hero, Speakers and Sponsors sections from the preview deployment._

Measured alignment on desktop (1669px viewport):

| Element | Width |
| --- | --- |
| Hero countdown | 489.08px |
| Hero CTA row | 489.08px |
| Speakers countdown | 358px |
| Speakers deadline line | 358px |

---

#### API expected request/response:

N/A — no API surface touched.

---

#### Refactors or changes not directly related to the main purpose of this PR:

- The sponsors copy was reworded from a hard limit to an invitation: **"Aceptamos postulaciones hasta el 15 de septiembre"** instead of "Fecha límite para ser sponsor".
- `Hero.tsx`: the countdown and the CTA row are now siblings inside a `w-fit` wrapper, which shifts the CTA row's entrance animation one beat later in the existing stagger.

---

#### Verification:

- `tsc --noEmit` passes.
- Verified in the browser at desktop and narrow widths across all five placements: digits tick, no layout shift, no horizontal overflow at 360/390px, and the CTA buttons wrap cleanly on mobile while the countdown keeps matching their block.
- Timezone check: all three constants parse to the same epoch under UTC, Tokyo, New York, Kiritimati and Montevideo, and resolve to the intended Uruguay wall-clock times per the IANA database (Uruguay has had no DST since 2015, so `-03:00` holds for both September and November).
- Expired state verified by temporarily targeting a past date — the cells are replaced by `CONVOCATORIA CERRADA` / `¡LLEGÓ EL DÍA!`.
- No hydration warnings or console errors.