### PR TITLE
fix(ui): use the Tailwind v4 syntax for CSS variable utilities

### DIFF
--- a/src/components/Admin/tareas/TaskFormDialog.tsx
+++ b/src/components/Admin/tareas/TaskFormDialog.tsx
@@ -218,7 +218,7 @@ export function TaskFormDialog({
                         <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
                       </Button>
                     </PopoverTrigger>
-                    <PopoverContent align="start" className="w-[--radix-popover-trigger-width] p-0">
+                    <PopoverContent align="start" className="w-(--radix-popover-trigger-width) p-0">
                       <Command>
                         <CommandInput placeholder="Buscar por nombre…" />
                         <CommandList>

--- a/src/components/shared/ui/chart.tsx
+++ b/src/components/shared/ui/chart.tsx
@@ -183,7 +183,7 @@ const ChartTooltipContent = React.forwardRef<
                     ) : (
                       !hideIndicator && (
                         <div
-                          className={cn("shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]", {
+                          className={cn("shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)", {
                             "h-2.5 w-2.5": indicator === "dot",
                             "w-1": indicator === "line",
                             "w-0 border-[1.5px] border-dashed bg-transparent": indicator === "dashed",

--- a/src/components/shared/ui/dropdown-menu.tsx
+++ b/src/components/shared/ui/dropdown-menu.tsx
@@ -46,7 +46,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] origin-[--radix-dropdown-menu-content-transform-origin] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -63,7 +63,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] origin-[--radix-dropdown-menu-content-transform-origin] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/src/components/shared/ui/sidebar.tsx
+++ b/src/components/shared/ui/sidebar.tsx
@@ -160,7 +160,7 @@ const Sidebar = React.forwardRef<
   if (collapsible === "none") {
     return (
       <div
-        className={cn("bg-sidebar text-sidebar-foreground flex h-full w-[--sidebar-width] flex-col", className)}
+        className={cn("bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col", className)}
         ref={ref}
         {...props}
       >
@@ -175,7 +175,7 @@ const Sidebar = React.forwardRef<
         <SheetContent
           data-sidebar="sidebar"
           data-mobile="true"
-          className="text-sidebar-foreground w-[--sidebar-width] border-0 bg-zinc-900 p-0 [&>button>svg]:h-5 [&>button>svg]:w-5 [&>button]:right-4 [&>button]:top-[1.125rem] [&>button]:flex [&>button]:h-6 [&>button]:w-6 [&>button]:items-center [&>button]:justify-center [&>button]:text-white [&>button]:hover:text-yellow-400"
+          className="text-sidebar-foreground w-(--sidebar-width) border-0 bg-zinc-900 p-0 [&>button>svg]:h-5 [&>button>svg]:w-5 [&>button]:right-4 [&>button]:top-[1.125rem] [&>button]:flex [&>button]:h-6 [&>button]:w-6 [&>button]:items-center [&>button]:justify-center [&>button]:text-white [&>button]:hover:text-yellow-400"
           style={
             {
               "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
@@ -201,24 +201,24 @@ const Sidebar = React.forwardRef<
       {/* This is what handles the sidebar gap on desktop */}
       <div
         className={cn(
-          "relative h-svh w-[--sidebar-width] bg-transparent transition-[width] duration-200 ease-linear",
+          "relative h-svh w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
           "group-data-[collapsible=offcanvas]:w-0",
           "group-data-[side=right]:rotate-180",
           variant === "floating" || variant === "inset"
             ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]"
-            : "group-data-[collapsible=icon]:w-[--sidebar-width-icon]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
         )}
       />
       <div
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
           side === "left"
             ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"
-            : "group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l",
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
           className
         )}
         {...props}
@@ -564,7 +564,7 @@ const SidebarMenuSkeleton = React.forwardRef<
     >
       {showIcon && <Skeleton className="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />}
       <Skeleton
-        className="h-4 max-w-[--skeleton-width] flex-1"
+        className="h-4 max-w-(--skeleton-width) flex-1"
         data-sidebar="menu-skeleton-text"
         style={
           {


### PR DESCRIPTION
#### How I solved it:

The admin sidebar had no width in production: it collapsed and rendered on top of
the page instead of beside it.

Cause: `main` moved to Tailwind v4, which reads a CSS variable inside an arbitrary
value from **parentheses**, not brackets — `w-(--sidebar-width)`, not
`w-[--sidebar-width]`. The bracket form does not generate a rule at all, so the
sidebar and its spacer were left at width 0. The utility classes came from the
shadcn components as generated for v3, so it failed quietly: the build succeeds,
TypeScript is clean, and only the rendered layout is wrong.

Fixed the same pattern everywhere it appears: the sidebar widths, the dropdown menu
transform origin, the popover trigger width and the chart tooltip swatches.

---

#### Checklist:

- [ ] I've added unit tests. — _N/A: no test runner in the repo. Verified against a
      production build (`pnpm build` + `pnpm start`), which is where this reproduces —
      `next dev` and `tsc` both look fine._
- [x] I've added inline documentation when the code is not trivial.
- [ ] I've updated the project documentation.
- [x] I've not used acronyms for file or variable names.
- [x] I've explicitly indicated if this PR needs deployment actions. — _None._

---

#### Screenshots:

Production build, admin at 1440px: sidebar 256px wide with the community switcher
visible, main content offset by 256px. Collapsed: 48px, content follows. Mobile
(390px): no horizontal overflow.

---

#### Refactors or changes not directly related to the main purpose of this PR:

None — the diff is 11 lines, all the same syntax change.
