### PR TITLE
chore(owy): run staff tools without approval prompts

### DIFF
--- a/owy/README.md
+++ b/owy/README.md
@@ -25,7 +25,7 @@ Slack / Telegram / HTTP (eve TUI)
 - **Conocimiento estático** (evento, comunidad, FAQ): `agent/sandbox/workspace/knowledge/*.md` — editá esos markdown para actualizar lo que Owy sabe.
 - **Datos en vivo** (grilla, OBS, countdown, stats): tools en `agent/tools/`.
 - **Fotos → grilla**: el staff manda una foto de la card física y `digitize_board_photo` la pasa por el OCR del sitio + sugerencia de lugar; la creación siempre se confirma y va por `create_track`.
-- **Permisos**: cualquiera puede preguntar; escribir (grilla/OBS/countdown), stats y OCR es **solo staff** (allowlist por env + aprobación humana con botones en el chat; borrar pide aprobación siempre).
+- **Permisos**: cualquiera puede preguntar; escribir (grilla/OBS/countdown/tareas/avisos), stats y OCR es **solo staff** (allowlist por env; quien no es staff queda denegado antes de que la tool corra). Las acciones se ejecutan directo: la confirmación es conversacional, no hay botones de aprobación (ver `lib/staff.ts` si se quieren volver a activar).
 - **Persona**: `agent/instructions.md` (rioplatense, amable, no inventa datos).
 
 ## Variables de entorno
@@ -100,7 +100,7 @@ En la TUI local sos `local-dev` → contás como staff: podés probar todo (gril
 
 1. "¿cuándo y dónde es la conf?" → responde desde knowledge, tono rioplatense.
 2. "mostrame la grilla" → llama `get_openspace_board`.
-3. "mové «X» a la Cueva a las 15:30" → botón de aprobación → mueve y avisa; con la grilla admin abierta en el navegador se ve moverse en vivo (el broadcast lo emite el sitio server-side; en local necesitás el sidecar de realtime del sitio corriendo).
+3. "mové «X» a la Cueva a las 15:30" → confirma y mueve; con la grilla admin abierta en el navegador se ve moverse en vivo (el broadcast lo emite el sitio server-side; en local necesitás el sidecar de realtime del sitio corriendo).
 4. "pausá la rotación de OBS" → `obs_control` → versión sube y la pantalla admin lo toma.
 5. Adjuntá una foto de una card física + "cargala en la grilla" → `digitize_board_photo` extrae los datos y sugiere lugar → confirmás → `create_track`.
 
@@ -121,7 +121,7 @@ Chequeos (desde `owy/`): `pnpm typecheck` · `pnpm build` (eve build) · `pnpm e
 2. **OAuth & Permissions → Bot Token Scopes**: `app_mentions:read`, `chat:write`, `im:history` (DMs), `files:read` (fotos para digitalizar cards), y para hilos sin re-mención: `channels:history` (+ `groups:history` si se usa en canales privados).
 3. Instalar la app en el workspace → copiar **Bot User OAuth Token** → `SLACK_BOT_TOKEN`. De **Basic Information** copiar el **Signing Secret** → `SLACK_SIGNING_SECRET`.
 4. **Event Subscriptions** → Request URL: `https://<owy-domain>/eve/v1/slack` → suscribir `app_mention` y `message.im` (+ `message.channels` para hilos).
-5. **Interactivity & Shortcuts** → misma URL (para los botones de aprobación).
+5. **Interactivity & Shortcuts** → misma URL. Hoy no hay botones de aprobación, pero Slack necesita esto para cualquier interacción futura (y para los prompts de eve si se reactivan).
 6. Invitar a `@Owy` a los canales donde deba responder.
 
 > Alternativa recomendada por eve si se prefiere no manejar tokens: **Vercel Connect** (`vercel connect create slack --name owy --triggers` + `connectSlackCredentials("slack/owy")` en `agent/channels/slack.ts`). Requiere permisos de admin en el workspace.

--- a/owy/agent/lib/staff.ts
+++ b/owy/agent/lib/staff.ts
@@ -74,20 +74,17 @@ interface ApprovalPolicyCtx extends ToolSessionCtx {
 }
 
 /**
- * Fixed mode, or one derived from the call's input (e.g. destructive actions).
- * "none" lets a read-only branch of a mixed tool through without prompting.
+ * Gate for staff-only tools, used as a tool's `approval` policy.
+ *
+ * Non-staff callers are denied outright — the model gets the reason and the
+ * tool never runs. Staff execute immediately: no human-in-the-loop button.
+ * The safety net is conversational (the instructions and skills tell Owy to
+ * confirm before mutating) plus `requireStaff` inside every `execute`.
+ *
+ * To bring the buttons back, return "user-approval" here for the calls that
+ * should pause — Slack needs Interactivity enabled for them to resolve.
  */
-type ApprovalModeValue = "none" | "once" | "always";
-type ApprovalMode = ApprovalModeValue | ((input: unknown) => ApprovalModeValue);
-
-/**
- * Approval policy for staff-only write tools: non-staff callers are denied
- * outright (the model gets the reason, no approval prompt is rendered), staff
- * get a human-in-the-loop prompt — every time (`always`) or only on the first
- * call per session (`once`). Tools still call `requireStaff` inside `execute`
- * as defense in depth.
- */
-export function staffApproval(mode: ApprovalMode = "once") {
+export function staffOnly() {
   return (ctx: ApprovalPolicyCtx) => {
     if (!isStaff(ctx)) {
       return {
@@ -97,14 +94,6 @@ export function staffApproval(mode: ApprovalMode = "once") {
       };
     }
 
-    const resolved = typeof mode === "function" ? mode(ctx.toolInput) : mode;
-    if (resolved === "none") {
-      return "not-applicable" as const;
-    }
-    if (resolved === "once" && ctx.approvedTools.has(ctx.toolName)) {
-      return "not-applicable" as const;
-    }
-
-    return "user-approval" as const;
+    return "not-applicable" as const;
   };
 }

--- a/owy/agent/skills/openspace-grid.md
+++ b/owy/agent/skills/openspace-grid.md
@@ -19,7 +19,7 @@ description: Usar cuando el staff pida crear, mover, editar, intercambiar o borr
    - celda libre → `move_track` / `create_track`
    - celda ocupada e intercambio deseado → `swap_tracks` (nunca borres para "hacer lugar")
    - cambio de datos sin mover → `update_track_info`
-   - borrar → `delete_track` (pide aprobación siempre; confirmá dos veces qué card es)
+   - borrar → `delete_track` (destructivo: confirmá dos veces qué card es antes de llamarlo)
 5. Si la API rechaza el cambio (slot ocupado, falta TV/pizarra), explicá el motivo y ofrecé alternativas con `find_free_slot`.
 6. Cerrá contando el resultado concreto ("Listo ✅ «X» quedó en Cueva 15:30").
 

--- a/owy/agent/tools/announce_to_staff.ts
+++ b/owy/agent/tools/announce_to_staff.ts
@@ -2,11 +2,11 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 import { normalizeText, resolveActiveEvent } from "../lib/board";
 import { owuApi } from "../lib/owu-api";
-import { requireStaff, staffApproval } from "../lib/staff";
+import { requireStaff, staffOnly } from "../lib/staff";
 
 export default defineTool({
   description:
-    "SOLO STAFF: publica un aviso en el tablero del staff del evento (les llega a las pantallas y al panel de coordinación). Se puede marcar como urgente y dirigir solo a quienes están asignados a una tarea. Lo firma Owy. Pide aprobación siempre: es un mensaje a personas reales.",
+    "SOLO STAFF: publica un aviso en el tablero del staff del evento (les llega a las pantallas y al panel de coordinación). Se puede marcar como urgente y dirigir solo a quienes están asignados a una tarea. Lo firma Owy. Le llega a personas reales: leele el texto a quien lo pide y esperá su OK antes de publicar; no publiques dos veces lo mismo.",
   inputSchema: z.object({
     body: z.string().min(1).max(2000).describe("El mensaje, redactado y listo para publicar"),
     urgent: z.boolean().optional().describe("true para marcarlo como urgente"),
@@ -15,7 +15,7 @@ export default defineTool({
       .optional()
       .describe("Si se indica, el aviso va solo a quienes están en esa tarea (id o parte del título)"),
   }),
-  approval: staffApproval("always"),
+  approval: staffOnly(),
   async execute({ body, urgent, task }, ctx) {
     requireStaff(ctx);
     const event = await resolveActiveEvent();

--- a/owy/agent/tools/cast_track.ts
+++ b/owy/agent/tools/cast_track.ts
@@ -2,7 +2,7 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 import { findCard, getBoard, resolveActiveEvent } from "../lib/board";
 import { owuApi } from "../lib/owu-api";
-import { requireStaff, staffApproval } from "../lib/staff";
+import { requireStaff, staffOnly } from "../lib/staff";
 
 export default defineTool({
   description:
@@ -11,10 +11,7 @@ export default defineTool({
     action: z.enum(["highlight", "clear", "status"]).describe("highlight, clear o status"),
     track: z.string().optional().describe("Para highlight: la charla (id o parte del título)"),
   }),
-  // Consultar qué hay en pantalla no pide aprobación; cambiarla sí.
-  approval: staffApproval((input) =>
-    (input as { action?: string } | undefined)?.action === "status" ? "none" : "once"
-  ),
+  approval: staffOnly(),
   async execute({ action, track }, ctx) {
     requireStaff(ctx);
     const event = await resolveActiveEvent();

--- a/owy/agent/tools/countdown_control.ts
+++ b/owy/agent/tools/countdown_control.ts
@@ -2,7 +2,7 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 import { resolveActiveEvent } from "../lib/board";
 import { owuApi } from "../lib/owu-api";
-import { requireStaff, staffApproval } from "../lib/staff";
+import { requireStaff, staffOnly } from "../lib/staff";
 
 export default defineTool({
   description:
@@ -12,7 +12,7 @@ export default defineTool({
     durationSeconds: z.number().int().positive().optional().describe("Para setDuration: duración en segundos"),
     targetTime: z.string().optional().describe("Para setTargetTime: timestamp ISO o hora 'HH:MM'"),
   }),
-  approval: staffApproval("once"),
+  approval: staffOnly(),
   async execute(input, ctx) {
     requireStaff(ctx);
     if (input.action === "setDuration" && !input.durationSeconds) {

--- a/owy/agent/tools/create_track.ts
+++ b/owy/agent/tools/create_track.ts
@@ -2,7 +2,7 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 import { findRoom, findSchedule, getBoard } from "../lib/board";
 import { owuApi } from "../lib/owu-api";
-import { requireStaff, staffApproval } from "../lib/staff";
+import { requireStaff, staffOnly } from "../lib/staff";
 
 export default defineTool({
   description:
@@ -16,7 +16,7 @@ export default defineTool({
     needsTV: z.boolean().optional().describe("La charla necesita TV/proyector"),
     needsWhiteboard: z.boolean().optional().describe("La charla necesita pizarra"),
   }),
-  approval: staffApproval("once"),
+  approval: staffOnly(),
   async execute(input, ctx) {
     requireStaff(ctx);
     const board = await getBoard();

--- a/owy/agent/tools/delete_track.ts
+++ b/owy/agent/tools/delete_track.ts
@@ -2,15 +2,15 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 import { findCard, getBoard } from "../lib/board";
 import { owuApi } from "../lib/owu-api";
-import { requireStaff, staffApproval } from "../lib/staff";
+import { requireStaff, staffOnly } from "../lib/staff";
 
 export default defineTool({
   description:
-    "SOLO STAFF: borra una card de la grilla del open space. Es destructivo y pide aprobación humana en cada uso. Confirmá siempre con la persona qué card exacta se borra antes de llamar esta tool.",
+    "SOLO STAFF: borra una card de la grilla del open space. Es destructivo y NO se puede deshacer: confirmá SIEMPRE con la persona qué card exacta se borra (título, sala y horario) y esperá su OK antes de llamar esta tool.",
   inputSchema: z.object({
     track: z.string().min(1).describe("Card a borrar (id o parte del título)"),
   }),
-  approval: staffApproval("always"),
+  approval: staffOnly(),
   async execute({ track }, ctx) {
     requireStaff(ctx);
     const board = await getBoard();

--- a/owy/agent/tools/manage_staff_task.ts
+++ b/owy/agent/tools/manage_staff_task.ts
@@ -4,7 +4,7 @@ import { resolveActiveEvent } from "../lib/board";
 import { eventToday } from "../lib/dates";
 import { normalizeText } from "../lib/board";
 import { owuApi, type StaffTask, type UpdateStaffTaskData } from "../lib/owu-api";
-import { requireStaff, staffApproval } from "../lib/staff";
+import { requireStaff, staffOnly } from "../lib/staff";
 
 const TIME = /^([01]\d|2[0-3]):[0-5]\d$/;
 const DAY = /^\d{4}-\d{2}-\d{2}$/;
@@ -63,10 +63,7 @@ export default defineTool({
     status: z.enum(["pending", "in_progress", "done", "blocked"]).optional().describe("Para set_status"),
     person: z.string().optional().describe("Para assign/unassign: nombre o userId de la persona"),
   }),
-  // Borrar una tarea pide aprobación siempre; el resto, una vez por sesión.
-  approval: staffApproval((input) =>
-    (input as { action?: string } | undefined)?.action === "delete" ? "always" : "once"
-  ),
+  approval: staffOnly(),
   async execute(input, ctx) {
     requireStaff(ctx);
     const event = await resolveActiveEvent();

--- a/owy/agent/tools/move_track.ts
+++ b/owy/agent/tools/move_track.ts
@@ -2,7 +2,7 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 import { findCard, findRoom, findSchedule, getBoard } from "../lib/board";
 import { owuApi } from "../lib/owu-api";
-import { requireStaff, staffApproval } from "../lib/staff";
+import { requireStaff, staffOnly } from "../lib/staff";
 
 export default defineTool({
   description:
@@ -20,7 +20,7 @@ export default defineTool({
     .refine((input) => input.room !== undefined || input.timeSlot !== undefined, {
       message: "Indicá al menos sala o horario destino",
     }),
-  approval: staffApproval("once"),
+  approval: staffOnly(),
   async execute(input, ctx) {
     requireStaff(ctx);
     const board = await getBoard();

--- a/owy/agent/tools/obs_control.ts
+++ b/owy/agent/tools/obs_control.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { defineTool } from "eve/tools";
 import { z } from "zod";
 import { owuApi, type OBSUpdateData } from "../lib/owu-api";
-import { requireStaff, staffApproval } from "../lib/staff";
+import { requireStaff, staffOnly } from "../lib/staff";
 
 export default defineTool({
   description:
@@ -24,7 +24,7 @@ export default defineTool({
     presetName: z.string().optional().describe("Para activate_preset: nombre del preset guardado"),
     directMode: z.boolean().optional().describe("Para set_direct_mode: true = fijar escena, false = rotación normal"),
   }),
-  approval: staffApproval("once"),
+  approval: staffOnly(),
   async execute(input, ctx) {
     requireStaff(ctx);
     const api = owuApi();

--- a/owy/agent/tools/shift_staff_tasks.ts
+++ b/owy/agent/tools/shift_staff_tasks.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { resolveActiveEvent } from "../lib/board";
 import { eventToday } from "../lib/dates";
 import { owuApi } from "../lib/owu-api";
-import { requireStaff, staffApproval } from "../lib/staff";
+import { requireStaff, staffOnly } from "../lib/staff";
 
 export default defineTool({
   description:
@@ -26,7 +26,7 @@ export default defineTool({
       .optional()
       .describe("Día afectado (default: hoy en Uruguay)"),
   }),
-  approval: staffApproval("always"),
+  approval: staffOnly(),
   async execute({ fromTime, deltaMinutes, day }, ctx) {
     requireStaff(ctx);
     const event = await resolveActiveEvent();

--- a/owy/agent/tools/swap_tracks.ts
+++ b/owy/agent/tools/swap_tracks.ts
@@ -2,7 +2,7 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 import { findCard, getBoard } from "../lib/board";
 import { owuApi } from "../lib/owu-api";
-import { requireStaff, staffApproval } from "../lib/staff";
+import { requireStaff, staffOnly } from "../lib/staff";
 
 export default defineTool({
   description:
@@ -11,7 +11,7 @@ export default defineTool({
     trackA: z.string().min(1).describe("Primera card (id o parte del título)"),
     trackB: z.string().min(1).describe("Segunda card (id o parte del título)"),
   }),
-  approval: staffApproval("once"),
+  approval: staffOnly(),
   async execute({ trackA, trackB }, ctx) {
     requireStaff(ctx);
     const board = await getBoard();

--- a/owy/agent/tools/update_track_info.ts
+++ b/owy/agent/tools/update_track_info.ts
@@ -2,7 +2,7 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 import { findCard, getBoard } from "../lib/board";
 import { owuApi } from "../lib/owu-api";
-import { requireStaff, staffApproval } from "../lib/staff";
+import { requireStaff, staffOnly } from "../lib/staff";
 
 export default defineTool({
   description:
@@ -25,7 +25,7 @@ export default defineTool({
         input.needsWhiteboard !== undefined,
       { message: "Indicá al menos un campo a cambiar" }
     ),
-  approval: staffApproval("once"),
+  approval: staffOnly(),
   async execute(input, ctx) {
     requireStaff(ctx);
     const board = await getBoard();


### PR DESCRIPTION
Aprobar una tool call desde Slack requiere tener **Interactivity & Shortcuts** apuntando a la app: hasta que eso esté, el botón se dibuja pero al tocarlo no pasa nada (Slack no tiene a dónde mandar el evento). Y aun con eso configurado, el tap extra es fricción en medio del evento.

`staffApproval(mode)` pasa a ser `staffOnly()`: conserva la mitad que importa — quien **no** es staff queda denegado **antes** de que la tool corra, con un motivo que Owy explica — y saca la pausa human-in-the-loop para el staff.

La confirmación se muda a la conversación: las instrucciones, las skills y las descripciones de las tools destructivas (`delete_track`, `announce_to_staff`) le piden a Owy que diga qué va a hacer y espere el OK. `requireStaff` sigue corriendo dentro de cada `execute` como segunda barrera.

Para volver a activar los botones alcanza con devolver `"user-approval"` en `lib/staff.ts` (y tener Interactivity configurado).

Verificado: `pnpm typecheck` y `eve build` limpios.