### PR TITLE
fix(realtime): subscribe to the backplane when a socket attaches

### DIFF
--- a/src/lib/realtime/hub.ts
+++ b/src/lib/realtime/hub.ts
@@ -40,6 +40,13 @@ class RealtimeHub {
   private warnedNoBackplane = false;
 
   attach(ws: WebSocket, options: { canPublish: boolean }): void {
+    // Join the backplane as soon as a socket lands here. Redis is what carries
+    // publishes between function instances, and `ensureRedis` is where this
+    // instance SUBSCRIBES — an instance that only holds sockets never
+    // publishes, so without this it would never hear anything another instance
+    // sent (a server-side write, or a client on a different instance).
+    void this.ensureRedis();
+
     const connection: Connection = { ws, canPublish: options.canPublish, channels: new Set() };
 
     ws.on("message", (data: unknown) => {


### PR DESCRIPTION
## El síntoma

El bot (o cualquier escritura server-side) actualiza la base, pero **el board no se entera**. En el navegador todo se ve sano: `sub` → `ok`, ping/pong, y nunca llega un `msg`.

## La causa

`ensureRedis()` es lo que **suscribe** a la instancia al canal de Redis, pero sólo se llamaba desde `publish()`. La instancia que sostiene el WebSocket del navegador nunca publica, así que **nunca se suscribía**:

```
Owy      → instancia A (API): publish → ensureRedis() ✅ → Redis PUBLISH
Navegador → instancia B (WS):  attach() … ensureRedis() ❌ → el evento se pierde
```

Esto no es sólo del bot: dos navegadores en instancias distintas (admin y kiosk, por ejemplo) tenían el mismo problema. Con `REDIS_URL` configurado y todo, el fan-out no llegaba.

## El fix

`attach()` se suma al backplane apenas entra un socket.

## Verificación

Con un Redis real y dos procesos separados (uno que sólo hace `attach`+`sub`, otro que sólo hace `publish`):

- **sin** el cambio → `❌ NOTHING RECEIVED`
- **con** el cambio → `✅ RECEIVED: {"t":"msg","ch":"event:TEST:sync","ev":"card_change",…}`

`pnpm tsc --noEmit` limpio.