### PR TITLE
feat(owy): preguntar con botones en vez de texto suelto

### DIFF
--- a/owy/README.md
+++ b/owy/README.md
@@ -25,7 +25,8 @@ Slack / Telegram / HTTP (eve TUI)
 - **Conocimiento estático** (evento, comunidad, FAQ): `agent/sandbox/workspace/knowledge/*.md` — editá esos markdown para actualizar lo que Owy sabe.
 - **Datos en vivo** (grilla, OBS, countdown, stats): tools en `agent/tools/`.
 - **Fotos → grilla**: el staff manda una foto de la card física y `digitize_board_photo` la pasa por el OCR del sitio + sugerencia de lugar; la creación siempre se confirma y va por `create_track`.
-- **Permisos**: cualquiera puede preguntar; escribir (grilla/OBS/countdown/tareas/avisos), stats y OCR es **solo staff** (allowlist por env; quien no es staff queda denegado antes de que la tool corra). Las acciones se ejecutan directo: la confirmación es conversacional, no hay botones de aprobación (ver `lib/staff.ts` si se quieren volver a activar).
+- **Permisos**: cualquiera puede preguntar; escribir (grilla/OBS/countdown/tareas/avisos), stats y OCR es **solo staff** (allowlist por env; quien no es staff queda denegado antes de que la tool corra). Las acciones se ejecutan directo: **no** hay botones de "Approve tool call" (ver `lib/staff.ts` si se quieren volver a activar).
+- **Botones de pregunta**: para desambiguar ("¿cuál de estas tres cards?") o confirmar algo irreversible ("¿borro «X»?"), Owy usa la tool `ask_question` de eve, que Slack dibuja como botones y Telegram como teclado. Siempre con `allowFreeform`, así también se puede contestar escribiendo.
 - **Persona**: `agent/instructions.md` (rioplatense, amable, no inventa datos).
 
 ## Variables de entorno
@@ -121,7 +122,7 @@ Chequeos (desde `owy/`): `pnpm typecheck` · `pnpm build` (eve build) · `pnpm e
 2. **OAuth & Permissions → Bot Token Scopes**: `app_mentions:read`, `chat:write`, `im:history` (DMs), `files:read` (fotos para digitalizar cards), y para hilos sin re-mención: `channels:history` (+ `groups:history` si se usa en canales privados).
 3. Instalar la app en el workspace → copiar **Bot User OAuth Token** → `SLACK_BOT_TOKEN`. De **Basic Information** copiar el **Signing Secret** → `SLACK_SIGNING_SECRET`.
 4. **Event Subscriptions** → Request URL: `https://<owy-domain>/eve/v1/slack` → suscribir `app_mention` y `message.im` (+ `message.channels` para hilos).
-5. **Interactivity & Shortcuts** → misma URL. Hoy no hay botones de aprobación, pero Slack necesita esto para cualquier interacción futura (y para los prompts de eve si se reactivan).
+5. **Interactivity & Shortcuts** → misma URL. **Necesario**: sin esto los botones de `ask_question` se dibujan pero al tocarlos no pasa nada (Slack no tiene a dónde mandar el click). Mientras no esté, la gente puede igual contestar escribiendo la opción.
 6. Invitar a `@Owy` a los canales donde deba responder.
 
 > Alternativa recomendada por eve si se prefiere no manejar tokens: **Vercel Connect** (`vercel connect create slack --name owy --triggers` + `connectSlackCredentials("slack/owy")` en `agent/channels/slack.ts`). Requiere permisos de admin en el workspace.

--- a/owy/agent/instructions.md
+++ b/owy/agent/instructions.md
@@ -42,6 +42,23 @@ Owy corre sobre [Eve](https://eve.dev), un framework de agentes durables. Si te 
 - Confirmá con la persona qué vas a hacer antes de ejecutar la acción, y contá el resultado después ("Listo, moví «X» a la Cueva a las 15:30 ✅").
 - Las cards en pantalla se actualizan solas después de tus cambios: no hace falta que nadie recargue nada.
 
+# Cuando preguntes, preguntá con botones
+
+Tenés la tool `ask_question`: hace la pregunta y la pausa hasta que contesten. Los canales la dibujan como **botones** (Slack) o **teclado** (Telegram), así que responder es un toque en vez de escribir.
+
+Usala en estos casos, en lugar de tirar la pregunta suelta en texto:
+
+- **Desambiguar**: si una tool te dice que "X" matchea varias cards, tareas o personas, no pegues la lista — preguntá con esas coincidencias como opciones.
+- **Confirmar algo que no se puede deshacer**: antes de `delete_track`, `manage_staff_task` con `delete`, `shift_staff_tasks` o `announce_to_staff`, preguntá con la acción exacta en el texto ("¿Borro «Lambdas» de Cueva 15:30?") y opciones tipo `Sí, borrala` / `No, dejala`. Recién con el sí llamás la tool.
+- **Elegir entre alternativas**: cuando `find_free_slot` o `digitize_board_photo` devuelven varias ubicaciones posibles, ofrecé las mejores como opciones.
+
+Reglas:
+
+- **Siempre `allowFreeform: true`**: así la persona también puede contestar escribiendo ("sí", "la de la Cueva") y no queda trabada si los botones no le responden.
+- Pocas opciones (2 a 5) y etiquetas cortas, que se leen en el celular.
+- Una pregunta por vez. Si ya tenés el dato o la persona ya te confirmó, no preguntes de nuevo.
+- Para cosas triviales o de solo lectura, no preguntes: hacelo y contá qué hiciste.
+
 # Formato por canal
 
 - **Slack**: podés usar formato (negrita, listas cortas). Respondé en el hilo.

--- a/owy/agent/skills/openspace-grid.md
+++ b/owy/agent/skills/openspace-grid.md
@@ -13,14 +13,14 @@ description: Usar cuando el staff pida crear, mover, editar, intercambiar o borr
 ## Procedimiento
 
 1. **Siempre mirá primero** el estado con `get_openspace_board`. No asumas qué hay en una celda.
-2. Identificá la card por título (o id si hay ambigüedad) y el destino por nombre de sala + horario. Las tools resuelven nombres aproximados y sin acentos.
-3. **Confirmá con la persona** la acción exacta antes de ejecutar ("¿Muevo «X» de Centro 15:00 a Cueva 15:30?").
+2. Identificá la card por título (o id si hay ambigüedad) y el destino por nombre de sala + horario. Las tools resuelven nombres aproximados y sin acentos; si te avisan que hay varias coincidencias, elegí con `ask_question`.
+3. **Confirmá con la persona** la acción exacta antes de ejecutar. Para mover o editar alcanza con decirlo; para **borrar** usá `ask_question` ("¿Borro «X» de Cueva 15:30?" con opciones `Sí, borrala` / `No`) y esperá el sí.
 4. Ejecutá la tool que corresponde:
    - celda libre → `move_track` / `create_track`
    - celda ocupada e intercambio deseado → `swap_tracks` (nunca borres para "hacer lugar")
    - cambio de datos sin mover → `update_track_info`
-   - borrar → `delete_track` (destructivo: confirmá dos veces qué card es antes de llamarlo)
-5. Si la API rechaza el cambio (slot ocupado, falta TV/pizarra), explicá el motivo y ofrecé alternativas con `find_free_slot`.
+   - borrar → `delete_track` (destructivo: confirmá con `ask_question` antes de llamarlo)
+5. Si la API rechaza el cambio (slot ocupado, falta TV/pizarra), explicá el motivo y ofrecé las alternativas de `find_free_slot` como opciones de `ask_question`.
 6. Cerrá contando el resultado concreto ("Listo ✅ «X» quedó en Cueva 15:30").
 
 ## Reglas

--- a/owy/agent/skills/staff-coordination.md
+++ b/owy/agent/skills/staff-coordination.md
@@ -10,7 +10,7 @@ El sitio tiene un tablero de tareas por evento: cada tarea tiene día, horario, 
 
 1. **Mirá primero** con `get_staff_tasks`. Filtros útiles: `today: true` (lo de hoy), `pendingOnly: true` (lo que falta), `status`. La respuesta trae también el **roster** con los `userId`, que es lo que necesitás para asignar.
 2. Identificá la tarea por título (o id si hay ambigüedad) y la persona por nombre (o userId).
-3. **Confirmá la acción** antes de ejecutarla, y contá el resultado después.
+3. **Confirmá la acción** antes de ejecutarla, y contá el resultado después. Para lo que afecta a mucha gente — `shift_staff_tasks`, `announce_to_staff`, borrar una tarea — confirmá con `ask_question` (opciones cortas tipo `Dale` / `Mejor no`) en vez de asumir.
 4. Usá la tool que corresponde:
    - crear / editar / cambiar estado / asignar / desasignar / borrar → `manage_staff_task`
    - correr en bloque los horarios de un día → `shift_staff_tasks`
@@ -28,6 +28,6 @@ El sitio tiene un tablero de tareas por evento: cada tarea tiene día, horario, 
 ## Reglas
 
 - Todo esto es **interno del staff**: no compartas tareas, nombres, roster ni avisos con asistentes.
-- Los avisos se los mandás a personas reales: pedí siempre confirmación (la tool ya la exige) y no los repitas si ya se publicó uno igual.
+- Los avisos se los mandás a personas reales: leé el texto y confirmá con `ask_question` antes de publicar; no repitas uno que ya salió.
 - Los horarios son hora de Uruguay; los días van como `YYYY-MM-DD` y por defecto es hoy.
 - Una acción por pedido: no reorganices el tablero entero por tu cuenta.


### PR DESCRIPTION
Devuelve los botones interactivos **sin** volver a poner el `Approve tool call`. Son dos mecanismos distintos de eve:

| | Qué es | Estado |
| --- | --- | --- |
| `approval` en una tool | El "Approve tool call: create_track" | **Sigue apagado** (#220) |
| `ask_question` | Tool built-in que el modelo llama cuando necesita una decisión | **Esto es lo que se activa acá** |

`ask_question` ya venía disponible (es parte del harness de eve, no hay que definir nada): Slack la dibuja como botones y Telegram como teclado. El tema es que a Owy nunca se le dijo de usarla, así que preguntaba en prosa.

## Qué cambia

Las instrucciones ahora le marcan tres momentos para usarla:

- **Desambiguar** — cuando "X" matchea varias cards, tareas o personas, en vez de pegar la lista.
- **Confirmar lo irreversible** — antes de `delete_track`, borrar una tarea, `shift_staff_tasks` o `announce_to_staff`: la acción exacta en el texto y opciones `Sí` / `No`. Recién con el sí llama la tool. Esto recupera la red de seguridad que daban las aprobaciones, pero con la decisión adentro de la conversación.
- **Elegir alternativas** — los slots libres que devuelven `find_free_slot` o `digitize_board_photo`.

Las skills de grilla y de staff dicen lo mismo en sus puntos de decisión.

## Detalle importante

Siempre con `allowFreeform: true`: además de tocar el botón se puede contestar escribiendo ("sí", o el texto de la opción). Eso hace que el flujo funcione **incluso sin** tener configurado *Interactivity & Shortcuts* en la app de Slack — que es justo lo que hacía que el botón de aprobar no hiciera nada. Igual conviene configurarlo para que el toque resuelva; está anotado en el README.

Verificado: `pnpm typecheck` y `eve build` limpios.