### PR TITLE
fix(orpc): let domain errors reach the client instead of a blank 500

### DIFF
--- a/src/lib/orpc/communities/services/index.ts
+++ b/src/lib/orpc/communities/services/index.ts
@@ -1,3 +1,4 @@
+import { ORPCError } from "@orpc/server";
 import { and, asc, eq } from "drizzle-orm";
 
 import { isValidCommunitySlug } from "../../../tenant";
@@ -132,12 +133,14 @@ async function requesterIsOwner(communityId: string, userId: string, isSiteStaff
 export async function addCommunityMember(input: AddCommunityMemberInput, requester: { userId: string; isSiteStaff: boolean }) {
   const [targetUser] = await db.select({ id: user.id }).from(user).where(eq(user.email, input.email.toLowerCase().trim()));
   if (!targetUser) {
-    throw new Error("No existe un usuario con ese email (debe iniciar sesión al menos una vez)");
+    throw new ORPCError("BAD_REQUEST", {
+      message: "No existe un usuario con ese email (debe iniciar sesión al menos una vez)",
+    });
   }
 
   // Only owners (or site staff) can grant the owner role
   if (input.role === "owner" && !(await requesterIsOwner(input.communityId, requester.userId, requester.isSiteStaff))) {
-    throw new Error("Solo un owner puede otorgar el rol owner");
+    throw new ORPCError("FORBIDDEN", { message: "Solo un owner puede otorgar el rol owner" });
   }
 
   const [row] = await db

--- a/src/lib/orpc/utilities/error-handler.ts
+++ b/src/lib/orpc/utilities/error-handler.ts
@@ -1,7 +1,17 @@
+import { ORPCError } from "@orpc/server";
+
 /**
  * Enhanced error handler for oRPC procedures
  */
 export const handleServiceError = (error: unknown, operation: string): never => {
+  // An ORPCError already carries the status and a message meant for the caller.
+  // Re-wrapping it as a plain Error downgrades it to a 500 with oRPC's generic
+  // "Internal server error", which is how domain errors ("that user has never
+  // signed in") reached the UI as a server crash.
+  if (error instanceof ORPCError) {
+    throw error;
+  }
+
   console.error(`❌ Failed to ${operation}:`);
   console.error('Error object:', error);
   console.error('Error stack:', error instanceof Error ? error.stack : 'N/A');


### PR DESCRIPTION
## What was happening

Adding a member to a community answered **"internal server error"**. The actual reason was sitting in the production logs:

```
POST /api/orpc/communities/members/add → 500
❌ Failed to add community member:
Error: No existe un usuario con ese email (debe iniciar sesión al menos una vez)
```

The backend knew exactly what to say — the message just never left the server.

## Why

`handleServiceError` re-wrapped **every** failure as a plain `Error`. Faced with an error it does not recognise, oRPC answers `INTERNAL_SERVER_ERROR` and hides the message, which is the right default: you do not want database internals leaking to the client.

The side effect is worse than it looks. The **9 `ORPCError`s** the staff-task services already throw with correct codes (`NOT_FOUND`, `FORBIDDEN`) were being flattened to 500 too — an `ORPCError` is an `Error`, so it hit the same `throw new Error(error.message)` branch and lost its status.

## The change

1. `handleServiceError` re-throws an `ORPCError` untouched. Unknown errors keep being hidden exactly as before.
2. The two community-member validations become client errors: `BAD_REQUEST` when the email has no user account, `FORBIDDEN` when someone who is not an owner tries to grant the owner role.

With this, `/admin/communities/<slug>` shows *"No existe un usuario con ese email (debe iniciar sesión al menos una vez)"* instead of a 500. That message stays in Spanish on purpose — it is user-facing copy in an admin UI that is written in Spanish.

`pnpm tsc --noEmit` clean.