### PR TITLE
feat(conf): tag every OWU CONF outbound link with UTM params

### DIFF
--- a/src/app/conf/components/Footer.tsx
+++ b/src/app/conf/components/Footer.tsx
@@ -1,7 +1,8 @@
 import { FaGithub, FaInstagram, FaLinkedin, FaSlack, FaTelegram } from "react-icons/fa6";
 
 import { SOCIAL_LINKS } from "app/lib/constants";
-import { addUtmParams } from "app/lib/utils";
+
+import { confUtm } from "../utm";
 
 import Reveal from "./Reveal";
 
@@ -31,7 +32,7 @@ export default function Footer() {
               key={label}
               aria-label={label}
               className="text-[#FBF5E7] transition-colors hover:text-[#F5BB03] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#F5BB03]"
-              href={addUtmParams(href)}
+              href={confUtm(href, "footer-social")}
               rel="noopener"
               target="_blank"
             >

--- a/src/app/conf/components/Hero.tsx
+++ b/src/app/conf/components/Hero.tsx
@@ -4,6 +4,8 @@ import { m } from "motion/react";
 
 import { CONF_DATES, INTERNAL_ROUTES, MAPS_URLS } from "app/lib/constants";
 
+import { confUtm } from "../utm";
+
 import Countdown from "./Countdown";
 import PillLink from "./PillLink";
 import { EASE_OUT } from "./Reveal";
@@ -56,7 +58,7 @@ export default function Hero() {
           </p>
           <a
             className="group mt-3.5 inline-flex items-center gap-2 text-base text-[#FBF5E7]/75 transition-colors hover:text-[#F5BB03] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#F5BB03] min-[1440px]:text-lg"
-            href={MAPS_URLS.meetupLocation}
+            href={confUtm(MAPS_URLS.meetupLocation, "hero-venue")}
             rel="noopener"
             target="_blank"
           >

--- a/src/app/conf/components/Marquee.tsx
+++ b/src/app/conf/components/Marquee.tsx
@@ -1,5 +1,7 @@
 import classNames from "classnames";
 
+import { confUtm } from "../utm";
+
 import { SPONSORS_2026 } from "./Sponsors";
 
 type MarqueeProps = {
@@ -31,7 +33,7 @@ export default function Marquee({ className }: MarqueeProps) {
                   key={`${name}-${i}`}
                   aria-label={isClone ? undefined : `Sitio de ${name}`}
                   className="flex h-[40px] w-[148px] shrink-0 items-center justify-center opacity-80 transition-[opacity,transform] duration-300 hover:scale-110 hover:!opacity-100 focus-visible:scale-110 focus-visible:!opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-8 focus-visible:outline-[#F5BB03] group-hover/marquee:opacity-40"
-                  href={website}
+                  href={confUtm(website, "sponsor-marquee")}
                   rel="noopener"
                   tabIndex={isClone ? -1 : undefined}
                   target="_blank"

--- a/src/app/conf/components/Meetups.tsx
+++ b/src/app/conf/components/Meetups.tsx
@@ -2,7 +2,7 @@ import { format, parseISO } from "date-fns";
 import { es } from "date-fns/locale";
 import Link from "next/link";
 
-import { addUtmParams } from "app/lib/utils";
+import { confUtm } from "../utm";
 
 import Reveal from "./Reveal";
 import SectionHeader from "./SectionHeader";
@@ -28,7 +28,7 @@ function EventCard({ title, name, datetime, event_url, index }: MeetupEvent & { 
       <Reveal amount={0.4} delay={index * 0.09} x={-32} y={0}>
       <Link
         className="group flex items-center gap-5 border-2 border-[#FBF5E7]/15 p-4 transition-colors hover:border-[#F5BB03] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#F5BB03] sm:gap-6 sm:p-5"
-        href={addUtmParams(event_url)}
+        href={confUtm(event_url, "meetups-agenda")}
         rel="noopener"
         target="_blank"
       >

--- a/src/app/conf/components/Navbar.tsx
+++ b/src/app/conf/components/Navbar.tsx
@@ -4,7 +4,8 @@ import Link from "next/link";
 import { m } from "motion/react";
 
 import { SOCIAL_LINKS } from "app/lib/constants";
-import { addUtmParams } from "app/lib/utils";
+
+import { confUtm } from "../utm";
 
 import PillLink from "./PillLink";
 import { EASE_OUT } from "./Reveal";
@@ -46,7 +47,7 @@ export default function Navbar() {
 
           <PillLink
             external
-            href={addUtmParams(SOCIAL_LINKS.slack)}
+            href={confUtm(SOCIAL_LINKS.slack, "navbar-cta")}
             sizeClassName="h-9 px-4 text-sm sm:h-12 sm:px-6 sm:text-base"
           >
             SUMATE

--- a/src/app/conf/components/Sponsors.tsx
+++ b/src/app/conf/components/Sponsors.tsx
@@ -1,5 +1,7 @@
 import { CONF_DATES, INTERNAL_ROUTES } from "app/lib/constants";
 
+import { confUtm } from "../utm";
+
 import Countdown from "./Countdown";
 import PillLink from "./PillLink";
 import Reveal from "./Reveal";
@@ -78,7 +80,7 @@ export default function Sponsors() {
             <Reveal amount={0.4} delay={0.12 + i * 0.07} scale={0.8} y={18}>
               <a
                 className="group flex h-[96px] items-center justify-center transition-transform hover:-translate-y-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#F5BB03]"
-                href={website}
+                href={confUtm(website, "sponsors-grid")}
                 rel="noopener"
                 target="_blank"
                 title={name}
@@ -106,7 +108,7 @@ export default function Sponsors() {
         <Reveal amount={0.4} delay={0.1} y={24}>
           <a
             className="group block focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#F5BB03]"
-            href="https://www.gub.uy/ministerio-educacion-cultura"
+            href={confUtm("https://www.gub.uy/ministerio-educacion-cultura", "institutional-support")}
             rel="noopener"
             target="_blank"
           >
@@ -121,7 +123,7 @@ export default function Sponsors() {
         <Reveal amount={0.4} delay={0.22} y={24}>
           <a
             className="group block focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#F5BB03]"
-            href="https://www.anii.org.uy/"
+            href={confUtm("https://www.anii.org.uy/", "institutional-support")}
             rel="noopener"
             target="_blank"
           >

--- a/src/app/conf/components/Team.tsx
+++ b/src/app/conf/components/Team.tsx
@@ -1,3 +1,5 @@
+import { confUtm } from "../utm";
+
 import Reveal from "./Reveal";
 import SectionHeader from "./SectionHeader";
 
@@ -156,7 +158,7 @@ export default function Team() {
                   <a
                     aria-label={`Perfil de LinkedIn de ${fullName}`}
                     className="group block focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#F5BB03]"
-                    href={linkedin}
+                    href={confUtm(linkedin, "team-linkedin")}
                     rel="noopener"
                     target="_blank"
                   >

--- a/src/app/conf/utm.ts
+++ b/src/app/conf/utm.ts
@@ -1,0 +1,46 @@
+import { CONF_DATES } from "app/lib/constants";
+import { addUtmParams } from "app/lib/utils";
+
+/*
+ * Every link that leaves /conf carries the same four fields, so the sites we send traffic to
+ * (sponsors, the community Slack, the meetup event pages) can tell OWU CONF apart from the
+ * rest of owu.uy — and tell our placements apart from each other:
+ *
+ *   utm_source    owu-conf    the property that sent the click, not the page
+ *   utm_medium    referral    the only medium analytics tools map to the Referral channel;
+ *                             an invented word lands under "Unassigned" on the other side
+ *   utm_campaign  the edition so next year's traffic doesn't blend into this one's
+ *   utm_content   the placement — the wall and the marquee link to the very same sponsor
+ *
+ * Internal links stay untagged on purpose (addUtmParams skips them): tagging our own pages
+ * opens a new session in analytics and throws away how the visit actually started.
+ */
+
+/* Read off the event date so a new edition only means updating CONF_DATES */
+const CAMPAIGN = `owu-conf-${CONF_DATES.event.slice(0, 4)}`;
+
+/** Where in /conf the click happened. One name per placement, reused across pages. */
+export type ConfLinkPlacement =
+  | "navbar-cta"
+  | "hero-venue"
+  | "sponsor-marquee"
+  | "sponsors-grid"
+  | "institutional-support"
+  | "team-linkedin"
+  | "meetups-agenda"
+  | "footer-social";
+
+/**
+ * Tags an outbound OWU CONF link for the destination's analytics
+ * @param url - The URL being linked to; internal and non-http hrefs come back untouched
+ * @param placement - The section of /conf the link lives in
+ * @returns The URL with the OWU CONF UTM fields applied
+ */
+export function confUtm(url: string, placement: ConfLinkPlacement): string {
+  return addUtmParams(url, {
+    source: "owu-conf",
+    medium: "referral",
+    campaign: CAMPAIGN,
+    content: placement,
+  });
+}

--- a/src/app/lib/utils.ts
+++ b/src/app/lib/utils.ts
@@ -39,15 +39,30 @@ export function alphabeticalSort<T>(array?: T[], key: keyof T = "name" as keyof 
   });
 }
 
+/** The four standard UTM fields. Empty ones are skipped, so a link only carries what it means. */
+export type UtmParams = {
+  /** The property the click came from, not the page it came from */
+  source?: string;
+  /** The channel type. `referral` is the value analytics tools group under Referral traffic */
+  medium?: string;
+  /** The initiative the link belongs to, e.g. one edition of an event */
+  campaign?: string;
+  /** The placement inside the page, so two links to the same destination stay distinguishable */
+  content?: string;
+};
+
 /**
  * Adds UTM parameters to external URLs only for tracking purposes
  * @param url - The URL to potentially add UTM parameters to
- * @param utmSource - The UTM source (defaults to 'la-meetup')
- * @param utmMedium - The UTM medium (defaults to 'owu')
+ * @param params - The UTM fields to append (defaults to the La Meetup source/medium pair)
  * @returns The URL with UTM parameters added only if it's an external link
  */
-export function addUtmParams(url: string, utmSource: string = "la-meetup", utmMedium: string = "owu"): string {
-  // Don't add UTM params to hash-only links, empty URLs, or internal links
+export function addUtmParams(
+  url: string,
+  { source = "la-meetup", medium = "owu", campaign, content }: UtmParams = {}
+): string {
+  // Don't add UTM params to hash-only links, empty URLs, or internal links:
+  // tagging our own pages restarts the visit as a new session and loses the original source
   if (!url || url === "#" || url.startsWith("#") || url.startsWith("/")) {
     return url;
   }
@@ -59,8 +74,17 @@ export function addUtmParams(url: string, utmSource: string = "la-meetup", utmMe
 
   try {
     const urlObj = new URL(url);
-    urlObj.searchParams.set("utm_source", utmSource);
-    urlObj.searchParams.set("utm_medium", utmMedium);
+    const fields = {
+      utm_source: source,
+      utm_medium: medium,
+      utm_campaign: campaign,
+      utm_content: content,
+    };
+
+    for (const [key, value] of Object.entries(fields)) {
+      // Lowercased: analytics tools report "Sponsors-Grid" and "sponsors-grid" as two placements
+      if (value) urlObj.searchParams.set(key, value.trim().toLowerCase());
+    }
 
     return urlObj.toString();
   } catch (error) {


### PR DESCRIPTION
Every outbound link on `/conf` now carries UTM parameters, so the sites we send traffic to can actually attribute it to OWU CONF.

#### How I solved it:

**The problem.** The sponsor wall, the hero marquee, the venue link, the MEC/ANII logos and the team profiles all linked out raw — a sponsor looking at their own analytics saw those visits as direct traffic. The three links that *were* tagged (navbar SUMATE, footer socials, meetup cards) were using the `addUtmParams` defaults, which say `utm_source=la-meetup&utm_medium=owu`: the conference showed up as La Meetup traffic.

**The taxonomy.** New `src/app/conf/utm.ts` holds one vocabulary for the whole route, so the four fields are decided once instead of per link:

| field | value | why |
| --- | --- | --- |
| `utm_source` | `owu-conf` | the property that sent the click, not the page |
| `utm_medium` | `referral` | the value analytics tools map to the Referral channel — an invented medium lands under "Unassigned" on the destination's side |
| `utm_campaign` | `owu-conf-2026` | read off `CONF_DATES.event`, so a new edition only means updating the date |
| `utm_content` | the placement | the wall and the marquee link to the *same* sponsor; without this they are one number |

`confUtm(url, placement)` is the only thing components call, and `ConfLinkPlacement` is a union type — a typo in a placement name is a build error, which is what keeps the report from splitting into near-duplicate rows six months from now.

**Placements tagged:** `navbar-cta` (SUMATE → Slack), `hero-venue` (Maps), `sponsor-marquee`, `sponsors-grid`, `institutional-support` (MEC + ANII), `team-linkedin`, `meetups-agenda`, `footer-social`. The navbar and footer are shared, so `/conf/sponsors` and `/conf/call-for-proposals` are covered too.

**`addUtmParams` (`src/app/lib/utils.ts`)** now takes the four standard fields as an options object instead of two positional strings, skips empty ones, and lowercases values (`Sponsors-Grid` and `sponsors-grid` are two different rows in every analytics tool). Every existing call site passes only a URL, so the rest of the site keeps emitting exactly `utm_source=la-meetup&utm_medium=owu` as before — this PR does not re-tag La Meetup.

**Deliberately left untagged:** internal links. The "¡QUIERO SER SPONSOR!" and "¡POSTULAR MI CHARLA!" buttons point at `/conf/sponsors` and `/conf/call-for-proposals`, and `addUtmParams` already refuses anything starting with `/` or `#` — UTM-tagging your own pages opens a fresh session in analytics and throws away how the visit actually started. The Google Forms iframes are untagged for the same reason it would be pointless: the form is not an analytics destination.

---

#### Checklist:

- [ ] I've added unit tests. — the repo has no test setup; verified by running the helper directly (below).
- [x] I've added inline documentation when the code is not trivial. — the field-by-field rationale lives at the top of `conf/utm.ts`.
- [ ] I've updated the project [documentation](https://github.com/owu-uy/owu/blob/production/readme.md).
- [x] I've not used acronyms for file or variable names. — except `utm`, which is the parameter name itself.
- [x] I've explicitly indicated if this PR needs deployment actions (e.g: Env variables). — none needed.

---

#### Screenshots:

No visual change: only `href` values move. The generated URLs, printed by running the real helper through `tsx`:

```
sponsor (grid)               https://sentry.io/?utm_source=owu-conf&utm_medium=referral&utm_campaign=owu-conf-2026&utm_content=sponsors-grid
sponsor (marquee)            https://sentry.io/?utm_source=owu-conf&utm_medium=referral&utm_campaign=owu-conf-2026&utm_content=sponsor-marquee
sponsor w/ existing query    https://www.crunchloop.io/?ref=owu&utm_source=owu-conf&utm_medium=referral&utm_campaign=owu-conf-2026&utm_content=sponsors-grid
navbar slack                 https://slack.owu.uy/?utm_source=owu-conf&utm_medium=referral&utm_campaign=owu-conf-2026&utm_content=navbar-cta
institutional                https://www.anii.org.uy/?utm_source=owu-conf&utm_medium=referral&utm_campaign=owu-conf-2026&utm_content=institutional-support
internal route (untouched)   /conf/sponsors
hash link (untouched)        #sponsors
mailto (untouched)           mailto:hola@owu.uy
legacy default (la meetup)   https://www.eventbrite.com/e/123?utm_source=la-meetup&utm_medium=owu
```

Note the third line: a URL that already carries its own query string keeps it.

`./node_modules/.bin/tsc --noEmit` passes. I did not run `next build` for this one — no CSS, deps or data flow changed.

---

#### API expected request/response:

N/A

---

#### Refactors or changes not directly related to the main purpose of this PR:

Only the `addUtmParams` signature change, which the new fields required. It is source-compatible with all 30 existing call sites.

One thing worth a second opinion: `team-linkedin`. Tagging personal LinkedIn profiles matches what `Meetups/2024/Member` already does, but nobody can read those stats — say the word and I drop that placement.
